### PR TITLE
Fix German IBAN format

### DIFF
--- a/src/main/java/org/iban4j/bban/BbanStructure.java
+++ b/src/main/java/org/iban4j/bban/BbanStructure.java
@@ -103,7 +103,7 @@ public class BbanStructure {
         structures.put(CountryCode.DE,
                 new BbanStructure(
                         BbanStructureEntry.bankCode(8, 'n'),
-                        BbanStructureEntry.accountNumber(10, 'c')));
+                        BbanStructureEntry.accountNumber(10, 'n')));
 
         structures.put(CountryCode.HR,
                 new BbanStructure(

--- a/src/test/java/org/iban4j/IbanUtilTest.java
+++ b/src/test/java/org/iban4j/IbanUtilTest.java
@@ -147,8 +147,8 @@ public class IbanUtilTest {
         @Test
         public void ibanValidationWithInvalidAccountNumberShouldThrowException() {
             expectedException.expect(IbanFormatException.class);
-            expectedException.expectMessage(containsString("must contain only digits or letters"));
-            IbanUtil.validate("DE8937040044053201300 ");
+            expectedException.expectMessage(containsString("must contain only digits"));
+            IbanUtil.validate("DE8937040044053201300A");
         }
 
         @Test


### PR DESCRIPTION
This pull request fixes the validation of german IBANs (or rather: BBANs, the bank account part to be specific). The bank account part of german accounts is completely numeric, not alpha-numeric (format is also documented as DE2!n8!n10!n by SWIFT).
