### PR TITLE
Allow optional validation of IBAN when generating the data

### DIFF
--- a/src/main/java/org/iban4j/Iban.java
+++ b/src/main/java/org/iban4j/Iban.java
@@ -291,7 +291,7 @@ public final class Iban {
         }
 
         /**
-         * Builds new iban instance.
+         * Builds new iban instance. This methods validates the generated IBAN.
          *
          * @return new iban instance.
          * @throws IbanFormatException, UnsupportedCountryException
@@ -299,6 +299,21 @@ public final class Iban {
          *  <a href="http://en.wikipedia.org/wiki/ISO_13616">ISO_13616</a>
          */
         public Iban build() throws IbanFormatException,
+                IllegalArgumentException, UnsupportedCountryException {
+            return build(true);
+        }
+
+        /**
+         * Builds new iban instance.
+         *
+         * @param validate boolean indicates if the generated IBAN needs to be
+         *  validated after generation
+         * @return new iban instance.
+         * @throws IbanFormatException, UnsupportedCountryException
+         *  if values are not parsable by Iban Specification
+         *  <a href="http://en.wikipedia.org/wiki/ISO_13616">ISO_13616</a>
+         */
+        public Iban build(boolean validate) throws IbanFormatException,
                 IllegalArgumentException, UnsupportedCountryException {
 
             // null checks
@@ -312,8 +327,9 @@ public final class Iban {
             // replace default check digit with calculated check digit
             final String ibanValue = IbanUtil.replaceCheckDigit(formattedIban, checkDigit);
 
-
-            IbanUtil.validate(ibanValue);
+            if (validate) {
+                IbanUtil.validate(ibanValue);
+            }
             return new Iban(ibanValue);
         }
 

--- a/src/test/java/org/iban4j/IbanTest.java
+++ b/src/test/java/org/iban4j/IbanTest.java
@@ -261,6 +261,16 @@ public class IbanTest {
                     .build();
             assertThat(iban.toFormattedString(), is(equalTo("AT14 1904 1023 4573 2012")));
         }
+
+        @Test
+        public void ibanConstructionWithShortBankCodeShouldNotThrowExceptionIfValidationIsDisabled() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.AT)
+                    .bankCode("1904")
+                    .accountNumber("A0234573201")
+                    .build(false);
+            assertThat(iban.toFormattedString(), is(equalTo("AT40 1904 A023 4573 201")));
+        }
     }
 
     public static class IbanGenerationExceptionalTest {
@@ -340,6 +350,15 @@ public class IbanTest {
                     .bankCode("1904")
                     .accountNumber("A0234573201")
                     .build();
+        }
+
+        @Test(expected = IbanFormatException.class)
+        public void ibanConstructionWithShortBankCodeShouldThrowExceptionIfValidationRequested() {
+            new Iban.Builder()
+                    .countryCode(CountryCode.AT)
+                    .bankCode("1904")
+                    .accountNumber("A0234573201")
+                    .build(true);
         }
     }
 }


### PR DESCRIPTION
Hi,

I have a use case where I generate random IBANs for test purpose. As I am using the BBAN structure to generate the data, I am sure that the data loaded is valid.

About 33% of the time of the build method is spent in validation (and 14.4% is spent in check digit validation - which is useless as the build computes it).

This patch allows to simply prevent validation to be executed globally.

I can push another patch to have a validation without computing the check digit for the particular case of the build methods if you like. Let me know.

Thanks!

Thierry
![selection_342](https://cloud.githubusercontent.com/assets/14175340/9729337/0a345e4e-560f-11e5-9f44-4d247db1f1b7.png)
