### PR TITLE
Create IBANs with one or more fields randomly filled.

### DIFF
--- a/src/main/java/org/iban4j/Iban.java
+++ b/src/main/java/org/iban4j/Iban.java
@@ -15,6 +15,9 @@
  */
 package org.iban4j;
 
+import java.util.List;
+import java.util.Random;
+
 import org.iban4j.bban.BbanStructure;
 import org.iban4j.bban.BbanStructureEntry;
 
@@ -169,6 +172,14 @@ public final class Iban {
         return ibanBuffer.toString().trim();
     }
 
+    public static Iban random() {
+        return new Iban.Builder().buildRandom();
+    }
+
+    public static Iban random(CountryCode cc) {
+        return new Iban.Builder().countryCode(cc).buildRandom();
+    }
+
     @Override
     public boolean equals(final Object obj) {
         if (obj instanceof Iban) {
@@ -195,6 +206,8 @@ public final class Iban {
         private String accountNumber;
         private String ownerAccountType;
         private String identificationNumber;
+
+        private final Random random = new Random();
 
         /**
          * Creates an Iban Builder instance.
@@ -333,6 +346,16 @@ public final class Iban {
             return new Iban(ibanValue);
         }
 
+        public Iban buildRandom() throws IbanFormatException,
+                IllegalArgumentException, UnsupportedCountryException {
+            if (countryCode == null) {
+                 List<CountryCode> codes = BbanStructure.getCountries();
+                this.countryCode(codes.get(random.nextInt(codes.size())));
+            }
+            fillMissingFieldsRandomly();
+            return build();
+        }
+
         /**
          * Returns formatted bban string.
          */
@@ -404,6 +427,54 @@ public final class Iban {
             }
         }
 
+        public void fillMissingFieldsRandomly() {
+            final BbanStructure structure = BbanStructure.forCountry(countryCode);
+
+            if (structure == null) {
+                throw new UnsupportedCountryException(countryCode.toString(),
+                        "Country code is not supported.");
+            }
+
+            for(final BbanStructureEntry entry : structure.getEntries()) {
+                switch (entry.getEntryType()) {
+                    case bank_code:
+                        if (bankCode == null) {
+                            bankCode = entry.getRandom();
+                        }
+                        break;
+                    case branch_code:
+                        if (branchCode == null) {
+                            branchCode = entry.getRandom();
+                        }
+                        break;
+                    case account_number:
+                        if (accountNumber == null) {
+                            accountNumber = entry.getRandom();
+                        }
+                        break;
+                    case national_check_digit:
+                        if (nationalCheckDigit == null) {
+                            nationalCheckDigit = entry.getRandom();
+                        }
+                        break;
+                    case account_type:
+                        if (accountType == null) {
+                            accountType = entry.getRandom();
+                        }
+                        break;
+                    case owner_account_number:
+                        if (ownerAccountType == null) {
+                            ownerAccountType = entry.getRandom();
+                        }
+                        break;
+                    case identification_number:
+                        if (identificationNumber == null) {
+                            identificationNumber = entry.getRandom();
+                        }
+                        break;
+                }
+            }
+        }
 
     }
 

--- a/src/main/java/org/iban4j/IbanUtil.java
+++ b/src/main/java/org/iban4j/IbanUtil.java
@@ -19,8 +19,6 @@ import org.iban4j.bban.BbanEntryType;
 import org.iban4j.bban.BbanStructure;
 import org.iban4j.bban.BbanStructureEntry;
 
-import java.util.Random;
-
 import static org.iban4j.IbanFormatException.IbanFormatViolation.*;
 /**
  * Iban Utility Class
@@ -39,8 +37,6 @@ public final class IbanUtil {
     private static final String ASSERT_UPPER_LETTERS = "[%s] must contain only upper case letters.";
     private static final String ASSERT_DIGITS_AND_LETTERS = "[%s] must contain only digits or letters.";
     private static final String ASSERT_DIGITS = "[%s] must contain only digits.";
-
-    private static final Random RANDOM = new Random();
 
     private IbanUtil() {
     }
@@ -173,23 +169,6 @@ public final class IbanUtil {
      */
     public static String getBankCode(final String iban) {
         return extractBbanEntry(iban, BbanEntryType.bank_code);
-    }
-
-    protected static Iban randomIban() {
-        return randomIban(randomCountryCode());
-    }
-
-    protected static Iban randomIban(CountryCode countryCode) {
-        final BbanStructure bbanStructure = getBbanStructure(countryCode);
-
-        // TODO implement
-        return null;
-    }
-
-    static CountryCode randomCountryCode() {
-        final CountryCode[] countryCodes = CountryCode.values();
-        final int randomIndex = RANDOM.nextInt(countryCodes.length);
-        return countryCodes[randomIndex];
     }
 
     /**

--- a/src/main/java/org/iban4j/bban/BbanStructure.java
+++ b/src/main/java/org/iban4j/bban/BbanStructure.java
@@ -17,10 +17,7 @@ package org.iban4j.bban;
 
 import org.iban4j.CountryCode;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.List;
+import java.util.*;
 
 
 /**
@@ -36,6 +33,7 @@ public class BbanStructure {
 
 
     private static final EnumMap<CountryCode, BbanStructure> structures;
+    private static final List<CountryCode> countries;
 
     static {
         structures = new EnumMap<CountryCode, BbanStructure>(CountryCode.class);
@@ -445,6 +443,10 @@ public class BbanStructure {
                         BbanStructureEntry.accountNumber(10, 'n'),
                         BbanStructureEntry.nationalCheckDigit(2, 'n')));
 
+        countries = new ArrayList<CountryCode>();
+        for (CountryCode code : structures.keySet()) {
+            countries.add(code);
+        }
 
     }
 
@@ -458,6 +460,10 @@ public class BbanStructure {
 
     public List<BbanStructureEntry> getEntries() {
         return Collections.unmodifiableList(Arrays.asList(entries));
+    }
+
+    public static List<CountryCode> getCountries() {
+        return countries;
     }
 
     /**

--- a/src/main/java/org/iban4j/bban/BbanStructureEntry.java
+++ b/src/main/java/org/iban4j/bban/BbanStructureEntry.java
@@ -15,6 +15,10 @@
  */
 package org.iban4j.bban;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
 /**
  * Bban Structure Entry representation.
  */
@@ -23,6 +27,26 @@ public class BbanStructureEntry {
     private final BbanEntryType entryType;
     private final EntryCharacterType characterType;
     private final int length;
+
+    private static Map<EntryCharacterType, char[]> charByCharacterType;
+    private final Random random = new Random();
+
+    static {
+        charByCharacterType = new HashMap<EntryCharacterType, char[]>();
+        StringBuilder charTypeN = new StringBuilder();
+        for (char ch = '0'; ch <= '9'; ch++) {
+            charTypeN.append(ch);
+        }
+        charByCharacterType.put(EntryCharacterType.n, charTypeN.toString().toCharArray());
+
+        StringBuilder charTypeA = new StringBuilder();
+        for (char ch = 'A'; ch <= 'Z'; ++ch) {
+            charTypeA.append(ch);
+        }
+        charByCharacterType.put(EntryCharacterType.a, charTypeA.toString().toCharArray());
+
+        charByCharacterType.put(EntryCharacterType.c, (charTypeN.toString() + charTypeA.toString()).toCharArray());
+    }
 
     private BbanStructureEntry(final BbanEntryType entryType,
                        final EntryCharacterType characterType,
@@ -83,6 +107,19 @@ public class BbanStructureEntry {
         n,  // Digits (numeric characters 0 to 9 only)
         a,  // Upper case letters (alphabetic characters A-Z only)
         c  // upper and lower case alphanumeric characters (A-Z, a-z and 0-9)
+    }
+
+    public String getRandom() {
+        StringBuilder s = new StringBuilder("");
+        char[] charChoices = charByCharacterType.get(characterType);
+        if (charChoices == null) {
+            throw new RuntimeException(String.format("programmer has not implemented choices for character type %s",
+                    characterType.name()));
+        }
+        for (int i = 0; i < getLength(); i++) {
+            s.append(charChoices[random.nextInt(charChoices.length)]);
+        }
+        return s.toString();
     }
 }
 

--- a/src/test/java/org/iban4j/IbanTest.java
+++ b/src/test/java/org/iban4j/IbanTest.java
@@ -360,5 +360,81 @@ public class IbanTest {
                     .accountNumber("A0234573201")
                     .build(true);
         }
+
+        @Test
+        public void ibanContructionRandom() {
+            for (int i = 0; i < 100; i++) {
+                new Iban.Builder().buildRandom();
+            }
+        }
+
+        @Test
+        public void ibanContructionRandomAcctRetainsSpecifiedCountry() {
+            Iban iban = new Iban.Builder().countryCode(CountryCode.AT).buildRandom();
+            assertThat(iban.getCountryCode(), is(equalTo(CountryCode.AT)));
+        }
+
+        @Test
+        public void ibanContructionRandomRetainsSpecifiedBankCode() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.AT)
+                    .bankCode("12345")
+                    .buildRandom();
+            assertThat(iban.getBankCode(), is(equalTo("12345")));
+        }
+
+        @Test
+        public void ibanContructionRandomDoesNotOverwriteBankAccount() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.AT)
+                    .accountNumber("12345678901")
+                    .buildRandom();
+            assertThat(iban.getAccountNumber(), is(equalTo("12345678901")));
+        }
+
+        @Test
+        public void ibanContructionRandomDoesNotOverwriteBranchCode() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.AL)
+                    .branchCode("1234")
+                    .buildRandom();
+            assertThat(iban.getBranchCode(), is(equalTo("1234")));
+        }
+
+        @Test
+        public void ibanContructionRandomDoesNotOverwriteNationalCheckDigit() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.AL)
+                    .nationalCheckDigit("1")
+                    .buildRandom();
+            assertThat(iban.getNationalCheckDigit(), is(equalTo("1")));
+        }
+
+        @Test
+        public void ibanContructionRandomDoesNotOverwriteAccountType() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.BR)
+                    .accountType("A")
+                    .buildRandom();
+            assertThat(iban.getAccountType(), is(equalTo("A")));
+        }
+
+        @Test
+        public void ibanContructionRandomDoesNotOverwriteOwnerAccountType() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.BR)
+                    .ownerAccountType("C")
+                    .buildRandom();
+            assertThat(iban.getOwnerAccountType(), is(equalTo("C")));
+        }
+
+        @Test
+        public void ibanContructionRandomDoesNotOverwriteIdentificationNumber() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.IS)
+                    .identificationNumber("1234567890")
+                    .buildRandom();
+            assertThat(iban.getIdentificationNumber(), is(equalTo("1234567890")));
+        }
     }
 }


### PR DESCRIPTION
Hi, I've got some some changes which may others may find useful.   Our primary use for this library has been generating test data.  As such, we've needed IBANs with one or more fields randomly filled.

This is done in the `Iban.Builder` class.  When the new `buildRandom()` method is called it uses the Bban definitions to supply random values for any fields which have not been supplied.  So, if you want to generate an Austrian IBAN for the bank with code `11111` you call:

`new Iban.Builder().countryCode(CountryCode.AT).bankCode("11111").randomIban()`

The call `new Iban.Builder().randomIban()` generates a completely random Iban.

There are convenience methods in the `Iban` class.  These are `Iban random()` and `Iban random(CountryCode)`.

