### PR TITLE
Add BBAN structure for 3 registered and 11 unregistered IBAN countries

### DIFF
--- a/src/main/java/org/iban4j/bban/BbanStructure.java
+++ b/src/main/java/org/iban4j/bban/BbanStructure.java
@@ -442,6 +442,72 @@ public class BbanStructure {
                         BbanStructureEntry.accountNumber(10, 'n'),
                         BbanStructureEntry.nationalCheckDigit(2, 'n')));
 
+        structures.put(CountryCode.SC,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(16, 'n'),
+                        BbanStructureEntry.accountType(3, 'a'))); // Currency
+
+        structures.put(CountryCode.LC,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(24, 'n')));
+
+        structures.put(CountryCode.ST,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(13, 'n')));
+
+        // IBAN structures according to Nordea
+
+        structures.put(CountryCode.DZ,
+                new BbanStructure(
+                        BbanStructureEntry.accountNumber(20, 'n')));
+
+        structures.put(CountryCode.AO,
+                new BbanStructure(
+                        BbanStructureEntry.accountNumber(21, 'n')));
+
+        structures.put(CountryCode.BJ,
+                new BbanStructure(
+                        BbanStructureEntry.accountNumber(24, 'n')));
+
+        structures.put(CountryCode.BI,
+                new BbanStructure(
+                        BbanStructureEntry.accountNumber(14, 'n')));
+
+        structures.put(CountryCode.CM,
+                new BbanStructure(
+                        BbanStructureEntry.accountNumber(23, 'n')));
+
+        structures.put(CountryCode.CV,
+                new BbanStructure(
+                        BbanStructureEntry.accountNumber(21, 'n')));
+
+        structures.put(CountryCode.CI,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(1, 'a'),
+                        BbanStructureEntry.accountNumber(23, 'n')));
+
+        structures.put(CountryCode.MG,
+                new BbanStructure(
+                        BbanStructureEntry.accountNumber(23, 'n')));
+
+        structures.put(CountryCode.ML,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(1, 'a'),
+                        BbanStructureEntry.accountNumber(23, 'n')));
+
+        structures.put(CountryCode.MZ,
+                new BbanStructure(
+                        BbanStructureEntry.accountNumber(21, 'n')));
+
+        structures.put(CountryCode.SN,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(1, 'a'),
+                        BbanStructureEntry.accountNumber(23, 'n')));
     }
 
     /**


### PR DESCRIPTION
I added some missing countries, three of which are described in the official ISO-13616 document. The rest are as described in the IBAN Wikipedia article, for which the source is the Nordea bank. (The codes for Ukraine and Iran were already included from that source)