### PR TITLE
Separate account and prefix

### DIFF
--- a/src/main/java/org/iban4j/Iban.java
+++ b/src/main/java/org/iban4j/Iban.java
@@ -15,16 +15,13 @@
  */
 package org.iban4j;
 
-import static org.iban4j.IbanFormatException.IbanFormatViolation.ACCOUNT_NUMBER_NOT_NULL;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.BANK_CODE_NOT_NULL;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.COUNTRY_CODE_NOT_NULL;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.IBAN_FORMATTING;
-
 import java.util.List;
 import java.util.Random;
 
 import org.iban4j.bban.BbanStructure;
 import org.iban4j.bban.BbanStructureEntry;
+
+import static org.iban4j.IbanFormatException.IbanFormatViolation.*;
 
 
 /**

--- a/src/main/java/org/iban4j/Iban.java
+++ b/src/main/java/org/iban4j/Iban.java
@@ -15,13 +15,16 @@
  */
 package org.iban4j;
 
+import static org.iban4j.IbanFormatException.IbanFormatViolation.ACCOUNT_NUMBER_NOT_NULL;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.BANK_CODE_NOT_NULL;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.COUNTRY_CODE_NOT_NULL;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.IBAN_FORMATTING;
+
 import java.util.List;
 import java.util.Random;
 
 import org.iban4j.bban.BbanStructure;
 import org.iban4j.bban.BbanStructureEntry;
-
-import static org.iban4j.IbanFormatException.IbanFormatViolation.*;
 
 
 /**
@@ -61,6 +64,15 @@ public final class Iban {
      */
     public String getCheckDigit() {
         return IbanUtil.getCheckDigit(value);
+    }
+
+    /**
+     * Returns iban's account number prefix.
+     *
+     * @return accountNumberPrefix String
+     */
+    public String getAccountNumberPrefix() {
+        return IbanUtil.getAccountNumberPrefix(value);
     }
 
     /**
@@ -224,6 +236,7 @@ public final class Iban {
         private String branchCode;
         private String nationalCheckDigit;
         private String accountType;
+        private String accountNumberPrefix;
         private String accountNumber;
         private String ownerAccountType;
         private String identificationNumber;
@@ -266,6 +279,17 @@ public final class Iban {
          */
         public Builder branchCode(final String branchCode) {
             this.branchCode = branchCode;
+            return this;
+        }
+
+        /**
+         * Sets iban's account number prefix
+         *
+         * @param accountNumberPrefix String
+         * @return builder Builder
+         */
+        public Builder accountNumberPrefix(final String accountNumberPrefix) {
+            this.accountNumberPrefix = accountNumberPrefix;
             return this;
         }
 
@@ -406,6 +430,9 @@ public final class Iban {
                     case branch_code:
                         sb.append(branchCode);
                         break;
+                    case account_number_prefix:
+                        sb.append(accountNumberPrefix);
+                        break;
                     case account_number:
                         sb.append(accountNumber);
                         break;
@@ -475,6 +502,11 @@ public final class Iban {
                     case branch_code:
                         if (branchCode == null) {
                             branchCode = entry.getRandom();
+                        }
+                        break;
+                    case account_number_prefix:
+                        if (accountNumberPrefix == null) {
+                        	accountNumberPrefix = entry.getRandom();
                         }
                         break;
                     case account_number:

--- a/src/main/java/org/iban4j/IbanUtil.java
+++ b/src/main/java/org/iban4j/IbanUtil.java
@@ -15,24 +15,11 @@
  */
 package org.iban4j;
 
-import static org.iban4j.IbanFormatException.IbanFormatViolation.BBAN_LENGTH;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.BBAN_ONLY_DIGITS;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.BBAN_ONLY_DIGITS_OR_LETTERS;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.BBAN_ONLY_UPPER_CASE_LETTERS;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.CHECK_DIGIT_ONLY_DIGITS;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.CHECK_DIGIT_TWO_DIGITS;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.COUNTRY_CODE_EXISTS;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.COUNTRY_CODE_TWO_LETTERS;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.COUNTRY_CODE_UPPER_CASE_LETTERS;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.IBAN_FORMATTING;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.IBAN_NOT_EMPTY;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.IBAN_NOT_NULL;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.IBAN_VALID_CHARACTERS;
-import static org.iban4j.IbanFormatException.IbanFormatViolation.UNKNOWN;
-
 import org.iban4j.bban.BbanEntryType;
 import org.iban4j.bban.BbanStructure;
 import org.iban4j.bban.BbanStructureEntry;
+
+import static org.iban4j.IbanFormatException.IbanFormatViolation.*;
 /**
  * Iban Utility Class
  */

--- a/src/main/java/org/iban4j/IbanUtil.java
+++ b/src/main/java/org/iban4j/IbanUtil.java
@@ -15,11 +15,24 @@
  */
 package org.iban4j;
 
+import static org.iban4j.IbanFormatException.IbanFormatViolation.BBAN_LENGTH;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.BBAN_ONLY_DIGITS;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.BBAN_ONLY_DIGITS_OR_LETTERS;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.BBAN_ONLY_UPPER_CASE_LETTERS;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.CHECK_DIGIT_ONLY_DIGITS;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.CHECK_DIGIT_TWO_DIGITS;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.COUNTRY_CODE_EXISTS;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.COUNTRY_CODE_TWO_LETTERS;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.COUNTRY_CODE_UPPER_CASE_LETTERS;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.IBAN_FORMATTING;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.IBAN_NOT_EMPTY;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.IBAN_NOT_NULL;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.IBAN_VALID_CHARACTERS;
+import static org.iban4j.IbanFormatException.IbanFormatViolation.UNKNOWN;
+
 import org.iban4j.bban.BbanEntryType;
 import org.iban4j.bban.BbanStructure;
 import org.iban4j.bban.BbanStructureEntry;
-
-import static org.iban4j.IbanFormatException.IbanFormatViolation.*;
 /**
  * Iban Utility Class
  */
@@ -176,6 +189,16 @@ public final class IbanUtil {
      */
     public static String getBban(final String iban) {
         return iban.substring(BBAN_INDEX);
+    }
+
+    /**
+     * Returns iban's account number.
+     *
+     * @param iban String
+     * @return accountNumberPrefix String
+     */
+    public static String getAccountNumberPrefix(final String iban) {
+        return extractBbanEntry(iban, BbanEntryType.account_number_prefix);
     }
 
     /**

--- a/src/main/java/org/iban4j/bban/BbanEntryType.java
+++ b/src/main/java/org/iban4j/bban/BbanEntryType.java
@@ -21,6 +21,7 @@ package org.iban4j.bban;
 public enum BbanEntryType {
         bank_code,
         branch_code,
+        account_number_prefix,
         account_number,
         national_check_digit,
         account_type,

--- a/src/main/java/org/iban4j/bban/BbanStructure.java
+++ b/src/main/java/org/iban4j/bban/BbanStructure.java
@@ -15,9 +15,13 @@
  */
 package org.iban4j.bban;
 
-import org.iban4j.CountryCode;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
 
-import java.util.*;
+import org.iban4j.CountryCode;
 
 
 /**
@@ -118,7 +122,8 @@ public class BbanStructure {
         structures.put(CountryCode.CZ,
                 new BbanStructure(
                         BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'n')));
+                        BbanStructureEntry.accountNumberPrefix(6, 'n'),
+                        BbanStructureEntry.accountNumber(10, 'n')));
 
         structures.put(CountryCode.DK,
                 new BbanStructure(
@@ -370,7 +375,8 @@ public class BbanStructure {
         structures.put(CountryCode.SK,
                 new BbanStructure(
                         BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'n')));
+                        BbanStructureEntry.accountNumberPrefix(6, 'n'),
+                        BbanStructureEntry.accountNumber(10, 'n')));
 
         structures.put(CountryCode.SI,
                 new BbanStructure(

--- a/src/main/java/org/iban4j/bban/BbanStructureEntry.java
+++ b/src/main/java/org/iban4j/bban/BbanStructureEntry.java
@@ -66,6 +66,11 @@ public class BbanStructureEntry {
                 EntryCharacterType.valueOf(String.valueOf(characterType)), length);
     }
 
+    public static BbanStructureEntry accountNumberPrefix(final int length, final char characterType) {
+        return new BbanStructureEntry(BbanEntryType.account_number_prefix,
+                EntryCharacterType.valueOf(String.valueOf(characterType)), length);
+    }
+
     public static BbanStructureEntry accountNumber(final int length, final char characterType) {
         return new BbanStructureEntry(BbanEntryType.account_number,
                 EntryCharacterType.valueOf(String.valueOf(characterType)), length);

--- a/src/test/java/org/iban4j/IbanTest.java
+++ b/src/test/java/org/iban4j/IbanTest.java
@@ -126,6 +126,18 @@ public class IbanTest {
         }
 
         @Test
+        public void ibanShouldReturnValidAccountNumberPrefix() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.SK)
+                    .bankCode("1200")
+                    .accountNumberPrefix("000019")
+                    .accountNumber("8742637541")
+                    .build();
+
+            assertThat(iban.getAccountNumberPrefix(), is(equalTo("000019")));
+        }
+
+        @Test
         public void ibanShouldReturnValidAccountNumber() {
             Iban iban = new Iban.Builder()
                     .countryCode(CountryCode.AT)
@@ -378,6 +390,16 @@ public class IbanTest {
         }
 
         @Test(expected = IbanFormatException.class)
+        public void ibanConstructionWithShortAccountPrefixShouldThrowException() {
+            new Iban.Builder()
+                    .countryCode(CountryCode.SK)
+                    .bankCode("1200")
+                    .accountNumberPrefix("19")
+                    .accountNumber("8742637541")
+                    .build();
+        }
+
+        @Test(expected = IbanFormatException.class)
         public void ibanConstructionWithShortBankCodeShouldThrowExceptionIfValidationRequested() {
             new Iban.Builder()
                     .countryCode(CountryCode.AT)
@@ -410,6 +432,15 @@ public class IbanTest {
                     .bankCode("12345")
                     .buildRandom();
             assertThat(iban.getBankCode(), is(equalTo("12345")));
+        }
+
+        @Test
+        public void ibanContructionRandomDoesNotOverwriteBankAccountPrefix() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.SK)
+                    .accountNumberPrefix("078901")
+                    .buildRandom();
+            assertThat(iban.getAccountNumberPrefix(), is(equalTo("078901")));
         }
 
         @Test

--- a/src/test/java/org/iban4j/TestDataHelper.java
+++ b/src/test/java/org/iban4j/TestDataHelper.java
@@ -100,7 +100,8 @@ final class TestDataHelper {
                 {new Iban.Builder()
                         .countryCode(CountryCode.CZ)
                         .bankCode("0800")
-                        .accountNumber("0000192000145399")
+                        .accountNumberPrefix("000019")
+                        .accountNumber("2000145399")
                         .build(), "CZ6508000000192000145399"},
                 {new Iban.Builder()
                         .countryCode(CountryCode.DK)
@@ -342,7 +343,8 @@ final class TestDataHelper {
                 {new Iban.Builder()
                         .countryCode(CountryCode.SK)
                         .bankCode("1200")
-                        .accountNumber("0000198742637541")
+                        .accountNumberPrefix("000019")
+                        .accountNumber("8742637541")
                         .build(), "SK3112000000198742637541"},
                 {new Iban.Builder()
                         .countryCode(CountryCode.SI)


### PR DESCRIPTION
In czech and slovak bank accounts, it is more convenient to use bank account number and number prefix separately. I created a new field for account number prefix and modified CZ and SK IBAN format to use the number prefix. 

When formatting the account number in these countries, these two numbers are separated with a dash, input forms (that could be dynamically generated from IBAN formats) would use 2 fields for each number. And both numbers are often shorter than max length (10 and 6 chars).