### PR TITLE
Padding bank & account #33

### DIFF
--- a/src/main/java/org/iban4j/Iban.java
+++ b/src/main/java/org/iban4j/Iban.java
@@ -20,6 +20,7 @@ import java.util.Random;
 
 import org.iban4j.bban.BbanStructure;
 import org.iban4j.bban.BbanStructureEntry;
+import org.iban4j.bban.BbanStructureEntry.EntryCharacterType;
 
 import static org.iban4j.IbanFormatException.IbanFormatViolation.*;
 
@@ -504,6 +505,76 @@ public final class Iban {
                         break;
                 }
             }
+        }
+
+        /**
+         * Aligns non-null numeric fields to its required length by prepending '0'.
+         */
+        public Builder addLeftPadding() {
+            final BbanStructure structure = BbanStructure.forCountry(countryCode);
+
+            if (structure == null) {
+                throw new UnsupportedCountryException(countryCode.toString(),
+                        "Country code is not supported.");
+            }
+            char zero = '0';
+            for(final BbanStructureEntry entry : structure.getEntries()) {
+                if (entry.getCharacterType() == EntryCharacterType.n) {
+                    switch (entry.getEntryType()) {
+                        case bank_code:
+                            if (bankCode != null) {
+                                bankCode = addLeftPadding(bankCode, entry.getLength(), zero);
+                            }
+                            break;
+                        case branch_code:
+                            if (branchCode != null) {
+                            	branchCode = addLeftPadding(branchCode, entry.getLength(), zero);
+                            }
+                            break;
+                        case account_number:
+                            if (accountNumber != null) {
+                                accountNumber = addLeftPadding(accountNumber, entry.getLength(), zero);
+                            }
+                            break;
+                        case national_check_digit:
+                            if (nationalCheckDigit != null) {
+                                nationalCheckDigit = addLeftPadding(nationalCheckDigit, entry.getLength(), zero);
+                            }
+                            break;
+                        case account_type:
+                            if (accountType != null) {
+                                accountType = addLeftPadding(accountType, entry.getLength(), zero);
+                            }
+                            break;
+                        case owner_account_number:
+                            if (ownerAccountType != null) {
+                                ownerAccountType = addLeftPadding(ownerAccountType, entry.getLength(), zero);
+                            }
+                            break;
+                        case identification_number:
+                            if (identificationNumber != null) {
+                                identificationNumber = addLeftPadding(identificationNumber, entry.getLength(), zero);
+                            }
+                            break;
+                    }
+                }
+            }
+            return this;
+        }
+
+        /** 
+         * Aligns string {@code value} to required {@code lenght} by prepending a {@code paddingChar}
+         */
+        private String addLeftPadding(final String value, final int lenght, final char paddingChar) {
+            if (value.length() < lenght) {
+                StringBuilder s = new StringBuilder(lenght);
+                for (int i = value.length(); i < lenght; i++) {
+                    s.append(paddingChar);
+                }
+                s.append(value);
+                return s.toString();
+            }
+            return value;
         }
 
     }

--- a/src/test/java/org/iban4j/IbanTest.java
+++ b/src/test/java/org/iban4j/IbanTest.java
@@ -466,4 +466,75 @@ public class IbanTest {
             assertThat(iban.getIdentificationNumber(), is(equalTo("1234567890")));
         }
     }
+
+    public static class IbanLeftPaddingTest {
+
+        @Test
+        public void ibanConstructionPaddingShortBankCode() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.CZ)
+                    .bankCode("100")
+                    .accountNumber("0000001023457320")
+                    .addLeftPadding()
+                    .build();
+            assertThat(iban.getBankCode(), is(equalTo("0100")));
+        }
+
+        @Test
+        public void ibanConstructionPaddingShouldNotChangeFullAlphabeticalFields() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.AZ)
+                    .bankCode("NABZ")
+                    .accountNumber("00000000137010001944")
+                    .addLeftPadding()
+                    .build();
+            assertThat(iban.getBankCode(), is(equalTo("NABZ")));
+        }
+
+        @Test(expected = IbanFormatException.class)
+        public void ibanConstructionPaddingShouldNotChangeShortAlphabeticFieldsShouldThrowException() {
+            new Iban.Builder()
+                    .countryCode(CountryCode.AZ)
+                    .bankCode("ABZ")
+                    .accountNumber("00000000137010001944")
+                    .addLeftPadding()
+                    .build();
+        }
+
+        @Test(expected = IbanFormatException.class)
+        public void ibanConstructionPaddingShouldNotChangeShortAlphanumericFieldsShouldThrowException() {
+            new Iban.Builder()
+                    .countryCode(CountryCode.AZ)
+                    .bankCode("NABZ")
+                    .accountNumber("137010001944")
+                    .addLeftPadding()
+                    .build();
+        }
+
+        @Test(expected = IbanFormatException.class)
+        public void ibanConstructionPaddingShouldNotFillInMissingFieldsShouldThrowException() {
+            new Iban.Builder()
+                    .countryCode(CountryCode.BR)
+                    .bankCode("00360305")
+                    .accountNumber("0009795493")
+                    .accountType("P")
+                    .ownerAccountType("1")
+                    .addLeftPadding()
+                    .build();
+        }
+
+        @Test
+        public void ibanConstructionPaddingFields() {
+            Iban iban = new Iban.Builder()
+                    .countryCode(CountryCode.BR)
+                    .bankCode("360305")
+                    .branchCode("1")
+                    .accountNumber("9795493")
+                    .accountType("P")
+                    .ownerAccountType("1")
+                    .addLeftPadding()
+                    .build();
+            assertThat(iban.toString(), is(equalTo("BR9700360305000010009795493P1")));
+        }
+    }
 }


### PR DESCRIPTION
I added zero padding to numeric fields when IBANs are being created. I am not sure about other fields - alphanumeric or alphabetical, but zero padding might come useful - regarding countries mentioned in the issue + CZ and SK.

The padding is in separate method in Builder (addLeftPadding()) and can be called at any point while building the IBAN. Unset fields are not created by this method, so incomplete IBANs stay invalid.
