### PR TITLE
Generate an iban with a country code chosen at random from a list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ A Java library for generation and validation of the International Bank Account N
 
  // How to generate random Iban
  Iban iban = Iban.random(CountryCode.AT);
+ Iban iban = Iban.random(Arrays.asList(CountryCode.AT, CountryCode.NL));
  Iban iban = Iban.random();
  Iban iban = new Iban.Builder()
                  .countryCode(CountryCode.AT)
+                 .bankCode("19043")
+                 .buildRandom();
+ Iban iban = new Iban.Builder()
+                 .countryCodes(Arrays.asList(CountryCode.AT, CountryCode.N))
                  .bankCode("19043")
                  .buildRandom();
 

--- a/src/main/java/org/iban4j/Iban.java
+++ b/src/main/java/org/iban4j/Iban.java
@@ -201,6 +201,10 @@ public final class Iban {
         return new Iban.Builder().countryCode(cc).buildRandom();
     }
 
+    public static Iban random(List<CountryCode> countryCodes) {
+        return new Iban.Builder().countryCodes(countryCodes).buildRandom();
+    }
+
     @Override
     public boolean equals(final Object obj) {
         if (obj instanceof Iban) {
@@ -220,6 +224,7 @@ public final class Iban {
     public final static class Builder {
 
         private CountryCode countryCode;
+        private List<CountryCode> countryCodes;
         private String bankCode;
         private String branchCode;
         private String nationalCheckDigit;
@@ -244,6 +249,17 @@ public final class Iban {
          */
         public Builder countryCode(final CountryCode countryCode) {
             this.countryCode = countryCode;
+            return this;
+        }
+
+        /**
+         * Sets iban's country codes for generation.
+         *
+         * @param countryCodes CountryCodes
+         * @return builder Builder
+         */
+        public Builder countryCodes(final List<CountryCode> countryCodes) {
+            this.countryCodes = countryCodes;
             return this;
         }
 
@@ -379,8 +395,14 @@ public final class Iban {
         public Iban buildRandom() throws IbanFormatException,
                 IllegalArgumentException, UnsupportedCountryException {
             if (countryCode == null) {
-                List<CountryCode> countryCodes = BbanStructure.supportedCountries();
-                this.countryCode(countryCodes.get(random.nextInt(countryCodes.size())));
+                List<CountryCode> countryCodesToChooseFrom;
+                if (this.countryCodes == null || this.countryCodes.isEmpty()) {
+                    countryCodesToChooseFrom = BbanStructure.supportedCountries();
+                }
+                else {
+                    countryCodesToChooseFrom = this.countryCodes;
+                }
+                this.countryCode(countryCodesToChooseFrom.get(random.nextInt(countryCodesToChooseFrom.size())));
             }
             fillMissingFieldsRandomly();
             return build();

--- a/src/test/java/org/iban4j/IbanTest.java
+++ b/src/test/java/org/iban4j/IbanTest.java
@@ -20,11 +20,10 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
 import java.util.Collection;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 
@@ -401,6 +400,15 @@ public class IbanTest {
 
             iban = Iban.random(CountryCode.AT);
             assertThat(iban.getCountryCode(), is(equalTo(CountryCode.AT)));
+        }
+
+        @Test
+        public void ibanContructionRandomAcctRetainsSpecifiedCountries() {
+            Iban iban = new Iban.Builder().countryCodes(Arrays.asList(CountryCode.AT, CountryCode.NL)).buildRandom();
+            assertThat(iban.getCountryCode(), either(equalTo(CountryCode.AT)).or(equalTo(CountryCode.NL)));
+
+            iban = Iban.random(Arrays.asList(CountryCode.NL, CountryCode.AT));
+            assertThat(iban.getCountryCode(), either(equalTo(CountryCode.AT)).or(equalTo(CountryCode.NL)));
         }
 
         @Test


### PR DESCRIPTION
Making it possible to generate an iban with a country code chosen randomly from a given set of country codes.
In case the specific country code of the iban to generate is one of a set of possible codes, you could pass these possible codes as a list to the builder.