### PR TITLE
#74: fix BY iban structure

### DIFF
--- a/src/main/java/org/iban4j/bban/BbanStructure.java
+++ b/src/main/java/org/iban4j/bban/BbanStructure.java
@@ -97,7 +97,7 @@ public class BbanStructure {
         structures.put(CountryCode.BY,
                 new BbanStructure(
                         BbanStructureEntry.bankCode(4, 'c'),
-                        BbanStructureEntry.accountType(4, 'n'),
+                        BbanStructureEntry.branchCode(4, 'n'),
                         BbanStructureEntry.accountNumber(16, 'c')));
 
         structures.put(CountryCode.CR,


### PR DESCRIPTION
fixes https://github.com/arturmkrtchyan/iban4j/issues/74

see https://bank.codes/iban/structure/belarus/
The strange thing is that the best was already correct.

```
{new Iban.Builder()
    .countryCode(CountryCode.BY)
    .bankCode("NBRB")
    .branchCode("3600") // <-- branchCode was given, not accountType
    .accountNumber("900000002Z00AB00")
    .build(), "BY13NBRB3600900000002Z00AB00"},
```