### PR TITLE
fix javadoc multiple throws tags

### DIFF
--- a/src/main/java/org/iban4j/Bic.java
+++ b/src/main/java/org/iban4j/Bic.java
@@ -34,8 +34,8 @@ public final class Bic {
      *
      * @param bic the String to be parsed.
      * @return a Bic object holding the value represented by the string argument.
-     * @throws BicFormatException if the String doesn't contain parsable Bic.
-     *         UnsupportedCountryException if bic's country is not supported.
+     * @throws BicFormatException          if the String doesn't contain parsable Bic.
+     * @throws UnsupportedCountryException if bic's country is not supported.
      */
     public static Bic valueOf(final String bic) throws BicFormatException,
             UnsupportedCountryException {
@@ -76,7 +76,7 @@ public final class Bic {
      * @return string representation of Bic's branch code, null if Bic has no branch code.
      */
     public String getBranchCode() {
-        if(BicUtil.hasBranchCode(value)) {
+        if (BicUtil.hasBranchCode(value)) {
             return BicUtil.getBranchCode(value);
         }
         return null;
@@ -85,7 +85,7 @@ public final class Bic {
     @Override
     public boolean equals(final Object obj) {
         if (obj instanceof Bic) {
-            return value.equals(((Bic)obj).value);
+            return value.equals(((Bic) obj).value);
         }
         return false;
     }

--- a/src/main/java/org/iban4j/BicUtil.java
+++ b/src/main/java/org/iban4j/BicUtil.java
@@ -38,8 +38,8 @@ public class BicUtil {
      * Validates bic.
      *
      * @param bic to be validated.
-     * @throws BicFormatException if bic is invalid.
-     *         UnsupportedCountryException if bic's country is not supported.
+     * @throws BicFormatException          if bic is invalid.
+     * @throws UnsupportedCountryException if bic's country is not supported.
      */
     public static void validate(final String bic) throws BicFormatException,
             UnsupportedCountryException {
@@ -51,7 +51,7 @@ public class BicUtil {
             validateCountryCode(bic);
             validateLocationCode(bic);
 
-            if(hasBranchCode(bic)) {
+            if (hasBranchCode(bic)) {
                 validateBranchCode(bic);
             }
         } catch (UnsupportedCountryException e) {
@@ -62,19 +62,19 @@ public class BicUtil {
     }
 
     private static void validateEmpty(final String bic) {
-        if(bic == null) {
+        if (bic == null) {
             throw new BicFormatException(BIC_NOT_NULL,
                     "Null can't be a valid Bic.");
         }
 
-        if(bic.length() == 0) {
+        if (bic.length() == 0) {
             throw new BicFormatException(BIC_NOT_EMPTY,
                     "Empty string can't be a valid Bic.");
         }
     }
 
     private static void validateLength(final String bic) {
-        if(bic.length() != BIC8_LENGTH && bic.length() != BIC11_LENGTH) {
+        if (bic.length() != BIC8_LENGTH && bic.length() != BIC11_LENGTH) {
             throw new BicFormatException(BIC_LENGTH_8_OR_11,
                     String.format("Bic length must be %d or %d",
                             BIC8_LENGTH, BIC11_LENGTH));
@@ -82,7 +82,7 @@ public class BicUtil {
     }
 
     private static void validateCase(final String bic) {
-        if(!bic.equals(bic.toUpperCase())) {
+        if (!bic.equals(bic.toUpperCase())) {
             throw new BicFormatException(BIC_ONLY_UPPER_CASE_LETTERS,
                     "Bic must contain only upper case letters.");
         }
@@ -90,8 +90,8 @@ public class BicUtil {
 
     private static void validateBankCode(final String bic) {
         String bankCode = getBankCode(bic);
-        for(final char ch : bankCode.toCharArray()) {
-            if(!Character.isLetter(ch)) {
+        for (final char ch : bankCode.toCharArray()) {
+            if (!Character.isLetter(ch)) {
                 throw new BicFormatException(BANK_CODE_ONLY_LETTERS, ch,
                         "Bank code must contain only letters.");
             }
@@ -100,7 +100,7 @@ public class BicUtil {
 
     private static void validateCountryCode(final String bic) {
         final String countryCode = getCountryCode(bic);
-        if(countryCode.trim().length() < COUNTRY_CODE_LENGTH ||
+        if (countryCode.trim().length() < COUNTRY_CODE_LENGTH ||
                 !countryCode.equals(countryCode.toUpperCase()) ||
                 !Character.isLetter(countryCode.charAt(0)) ||
                 !Character.isLetter(countryCode.charAt(1))) {
@@ -109,7 +109,7 @@ public class BicUtil {
                     "Bic country code must contain upper case letters");
         }
 
-        if(CountryCode.getByCode(countryCode) == null) {
+        if (CountryCode.getByCode(countryCode) == null) {
             throw new UnsupportedCountryException(countryCode,
                     "Country code is not supported.");
         }
@@ -117,8 +117,8 @@ public class BicUtil {
 
     private static void validateLocationCode(final String bic) {
         final String locationCode = getLocationCode(bic);
-        for(char ch : locationCode.toCharArray()) {
-            if(!Character.isLetterOrDigit(ch)) {
+        for (char ch : locationCode.toCharArray()) {
+            if (!Character.isLetterOrDigit(ch)) {
                 throw new BicFormatException(LOCATION_CODE_ONLY_LETTERS_OR_DIGITS,
                         ch, "Location code must contain only letters or digits.");
             }
@@ -127,8 +127,8 @@ public class BicUtil {
 
     private static void validateBranchCode(final String bic) {
         final String branchCode = getBranchCode(bic);
-        for(final char ch : branchCode.toCharArray()) {
-            if(!Character.isLetterOrDigit(ch)) {
+        for (final char ch : branchCode.toCharArray()) {
+            if (!Character.isLetterOrDigit(ch)) {
                 throw new BicFormatException(BRANCH_CODE_ONLY_LETTERS_OR_DIGITS,
                         ch, "Branch code must contain only letters or digits.");
             }

--- a/src/main/java/org/iban4j/Iban.java
+++ b/src/main/java/org/iban4j/Iban.java
@@ -140,10 +140,9 @@ public final class Iban {
      *
      * @param iban the String to be parsed.
      * @return an Iban object holding the value represented by the string argument.
-     * @throws IbanFormatException if the String doesn't contain parsable Iban
-     *         InvalidCheckDigitException if Iban has invalid check digit
-     *         UnsupportedCountryException if Iban's Country is not supported.
-     *
+     * @throws IbanFormatException         if the String doesn't contain parsable Iban
+     * @throws InvalidCheckDigitException  if Iban has invalid check digit
+     * @throws UnsupportedCountryException if Iban's Country is not supported.
      */
     public static Iban valueOf(final String iban) throws IbanFormatException,
             InvalidCheckDigitException, UnsupportedCountryException {
@@ -154,13 +153,12 @@ public final class Iban {
     /**
      * Returns an Iban object holding the value of the specified String.
      *
-     * @param iban the String to be parsed.
+     * @param iban   the String to be parsed.
      * @param format the format of the Iban.
      * @return an Iban object holding the value represented by the string argument.
-     * @throws IbanFormatException if the String doesn't contain parsable Iban
-     *         InvalidCheckDigitException if Iban has invalid check digit
-     *         UnsupportedCountryException if Iban's Country is not supported.
-     *
+     * @throws IbanFormatException         if the String doesn't contain parsable Iban
+     * @throws InvalidCheckDigitException  if Iban has invalid check digit
+     * @throws UnsupportedCountryException if Iban's Country is not supported.
      */
     public static Iban valueOf(final String iban, final IbanFormat format) throws IbanFormatException,
             InvalidCheckDigitException, UnsupportedCountryException {
@@ -168,7 +166,7 @@ public final class Iban {
             case Default:
                 final String ibanWithoutSpaces = iban.replace(" ", "");
                 final Iban ibanObj = valueOf(ibanWithoutSpaces);
-                if(ibanObj.toFormattedString().equals(iban)) {
+                if (ibanObj.toFormattedString().equals(iban)) {
                     return ibanObj;
                 }
                 throw new IbanFormatException(IBAN_FORMATTING,
@@ -204,7 +202,7 @@ public final class Iban {
     @Override
     public boolean equals(final Object obj) {
         if (obj instanceof Iban) {
-            return value.equals(((Iban)obj).value);
+            return value.equals(((Iban) obj).value);
         }
         return false;
     }
@@ -328,9 +326,9 @@ public final class Iban {
          * Builds new iban instance. This methods validates the generated IBAN.
          *
          * @return new iban instance.
-         * @exception IbanFormatException if values are not parsable by Iban Specification
-         *  <a href="http://en.wikipedia.org/wiki/ISO_13616">ISO_13616</a>
-         * @exception UnsupportedCountryException if country is not supported
+         * @throws IbanFormatException         if values are not parsable by Iban Specification
+         *                                     <a href="http://en.wikipedia.org/wiki/ISO_13616">ISO_13616</a>
+         * @throws UnsupportedCountryException if country is not supported
          */
         public Iban build() throws IbanFormatException,
                 IllegalArgumentException, UnsupportedCountryException {
@@ -341,11 +339,11 @@ public final class Iban {
          * Builds new iban instance.
          *
          * @param validate boolean indicates if the generated IBAN needs to be
-         *  validated after generation
+         *                 validated after generation
          * @return new iban instance.
-         * @exception IbanFormatException if values are not parsable by Iban Specification
-         *  <a href="http://en.wikipedia.org/wiki/ISO_13616">ISO_13616</a>
-         * @exception UnsupportedCountryException if country is not supported
+         * @throws IbanFormatException         if values are not parsable by Iban Specification
+         *                                     <a href="http://en.wikipedia.org/wiki/ISO_13616">ISO_13616</a>
+         * @throws UnsupportedCountryException if country is not supported
          */
         public Iban build(boolean validate) throws IbanFormatException,
                 IllegalArgumentException, UnsupportedCountryException {
@@ -371,10 +369,9 @@ public final class Iban {
          * Builds random iban instance.
          *
          * @return random iban instance.
-         * @exception IbanFormatException if values are not parsable by Iban Specification
-         *  <a href="http://en.wikipedia.org/wiki/ISO_13616">ISO_13616</a>
-         * @exception UnsupportedCountryException if country is not supported
-         *
+         * @throws IbanFormatException         if values are not parsable by Iban Specification
+         *                                     <a href="http://en.wikipedia.org/wiki/ISO_13616">ISO_13616</a>
+         * @throws UnsupportedCountryException if country is not supported
          */
         public Iban buildRandom() throws IbanFormatException,
                 IllegalArgumentException, UnsupportedCountryException {
@@ -398,7 +395,7 @@ public final class Iban {
                         "Country code is not supported.");
             }
 
-            for(final BbanStructureEntry entry : structure.getEntries()) {
+            for (final BbanStructureEntry entry : structure.getEntries()) {
                 switch (entry.getEntryType()) {
                     case bank_code:
                         sb.append(bankCode);
@@ -465,7 +462,7 @@ public final class Iban {
                         "Country code is not supported.");
             }
 
-            for(final BbanStructureEntry entry : structure.getEntries()) {
+            for (final BbanStructureEntry entry : structure.getEntries()) {
                 switch (entry.getEntryType()) {
                     case bank_code:
                         if (bankCode == null) {

--- a/src/main/java/org/iban4j/IbanUtil.java
+++ b/src/main/java/org/iban4j/IbanUtil.java
@@ -20,6 +20,7 @@ import org.iban4j.bban.BbanStructure;
 import org.iban4j.bban.BbanStructureEntry;
 
 import static org.iban4j.IbanFormatException.IbanFormatViolation.*;
+
 /**
  * Iban Utility Class
  */
@@ -46,9 +47,8 @@ public final class IbanUtil {
      * <a href="http://en.wikipedia.org/wiki/ISO_13616#Generating_IBAN_check_digits">Check Digit</a>.
      *
      * @param iban string value
-     * @throws IbanFormatException if iban contains invalid character.
-     *
      * @return check digit as String
+     * @throws IbanFormatException if iban contains invalid character.
      */
     public static String calculateCheckDigit(final String iban) throws IbanFormatException {
         final String reformattedIban = replaceCheckDigit(iban,
@@ -63,9 +63,9 @@ public final class IbanUtil {
      * Validates iban.
      *
      * @param iban to be validated.
-     * @throws IbanFormatException if iban is invalid.
-     *         UnsupportedCountryException if iban's country is not supported.
-     *         InvalidCheckDigitException if iban has invalid check digit.
+     * @throws IbanFormatException         if iban is invalid.
+     * @throws UnsupportedCountryException if iban's country is not supported.
+     * @throws InvalidCheckDigitException  if iban has invalid check digit.
      */
     public static void validate(final String iban) throws IbanFormatException,
             InvalidCheckDigitException, UnsupportedCountryException {
@@ -90,11 +90,11 @@ public final class IbanUtil {
     /**
      * Validates iban.
      *
-     * @param iban to be validated.
+     * @param iban   to be validated.
      * @param format to be used in validation.
-     * @throws IbanFormatException if iban is invalid.
-     *         UnsupportedCountryException if iban's country is not supported.
-     *         InvalidCheckDigitException if iban has invalid check digit.
+     * @throws IbanFormatException         if iban is invalid.
+     * @throws UnsupportedCountryException if iban's country is not supported.
+     * @throws InvalidCheckDigitException  if iban has invalid check digit.
      */
     public static void validate(final String iban, final IbanFormat format) throws IbanFormatException,
             InvalidCheckDigitException, UnsupportedCountryException {
@@ -102,7 +102,7 @@ public final class IbanUtil {
             case Default:
                 final String ibanWithoutSpaces = iban.replace(" ", "");
                 validate(ibanWithoutSpaces);
-                if(!toFormattedString(ibanWithoutSpaces).equals(iban)) {
+                if (!toFormattedString(ibanWithoutSpaces).equals(iban)) {
                     throw new IbanFormatException(IBAN_FORMATTING,
                             String.format("Iban must be formatted using 4 characters and space combination. " +
                                     "Instead of [%s]", iban));
@@ -116,8 +116,8 @@ public final class IbanUtil {
 
     /**
      * Checks whether country is supporting iban.
-     * @param countryCode {@link org.iban4j.CountryCode}
      *
+     * @param countryCode {@link org.iban4j.CountryCode}
      * @return boolean true if country supports iban, false otherwise.
      */
     public static boolean isSupportedCountry(final CountryCode countryCode) {
@@ -291,12 +291,12 @@ public final class IbanUtil {
     }
 
     private static void validateEmpty(final String iban) {
-        if(iban == null) {
+        if (iban == null) {
             throw new IbanFormatException(IBAN_NOT_NULL,
                     "Null can't be a valid Iban.");
         }
 
-        if(iban.length() == 0) {
+        if (iban.length() == 0) {
             throw new IbanFormatException(IBAN_NOT_EMPTY,
                     "Empty string can't be a valid Iban.");
         }
@@ -304,7 +304,7 @@ public final class IbanUtil {
 
     private static void validateCountryCode(final String iban) {
         // check if iban contains 2 char country code
-        if(iban.length() < COUNTRY_CODE_LENGTH) {
+        if (iban.length() < COUNTRY_CODE_LENGTH) {
             throw new IbanFormatException(COUNTRY_CODE_TWO_LETTERS, iban,
                     "Iban must contain 2 char country code.");
         }
@@ -312,14 +312,14 @@ public final class IbanUtil {
         final String countryCode = getCountryCode(iban);
 
         // check case sensitivity
-        if(!countryCode.equals(countryCode.toUpperCase()) ||
-            !Character.isLetter(countryCode.charAt(0)) ||
-            !Character.isLetter(countryCode.charAt(1))) {
+        if (!countryCode.equals(countryCode.toUpperCase()) ||
+                !Character.isLetter(countryCode.charAt(0)) ||
+                !Character.isLetter(countryCode.charAt(1))) {
             throw new IbanFormatException(COUNTRY_CODE_UPPER_CASE_LETTERS, countryCode,
                     "Iban country code must contain upper case letters.");
         }
 
-        if(CountryCode.getByCode(countryCode) == null) {
+        if (CountryCode.getByCode(countryCode) == null) {
             throw new IbanFormatException(COUNTRY_CODE_EXISTS, countryCode,
                     "Iban contains non existing country code.");
         }
@@ -335,7 +335,7 @@ public final class IbanUtil {
 
     private static void validateCheckDigitPresence(final String iban) {
         // check if iban contains 2 digit check digit
-        if(iban.length() < COUNTRY_CODE_LENGTH + CHECK_DIGIT_LENGTH) {
+        if (iban.length() < COUNTRY_CODE_LENGTH + CHECK_DIGIT_LENGTH) {
             throw new IbanFormatException(CHECK_DIGIT_TWO_DIGITS,
                     iban.substring(COUNTRY_CODE_LENGTH),
                     "Iban must contain 2 digit check digit.");
@@ -344,8 +344,8 @@ public final class IbanUtil {
         final String checkDigit = getCheckDigit(iban);
 
         // check digits
-        if(!Character.isDigit(checkDigit.charAt(0)) ||
-           !Character.isDigit(checkDigit.charAt(1))) {
+        if (!Character.isDigit(checkDigit.charAt(0)) ||
+                !Character.isDigit(checkDigit.charAt(1))) {
             throw new IbanFormatException(CHECK_DIGIT_ONLY_DIGITS, checkDigit,
                     "Iban's check digit should contain only digits.");
         }
@@ -368,7 +368,7 @@ public final class IbanUtil {
                                             final BbanStructure structure) {
         final String bban = getBban(iban);
         int bbanEntryOffset = 0;
-        for(final BbanStructureEntry entry : structure.getEntries()) {
+        for (final BbanStructureEntry entry : structure.getEntries()) {
             final int entryLength = entry.getLength();
             final String entryValue = bban.substring(bbanEntryOffset,
                     bbanEntryOffset + entryLength);
@@ -384,8 +384,8 @@ public final class IbanUtil {
                                                        final String entryValue) {
         switch (entry.getCharacterType()) {
             case a:
-                for(char ch: entryValue.toCharArray()) {
-                    if(!Character.isUpperCase(ch)) {
+                for (char ch : entryValue.toCharArray()) {
+                    if (!Character.isUpperCase(ch)) {
                         throw new IbanFormatException(BBAN_ONLY_UPPER_CASE_LETTERS,
                                 entry.getEntryType(), entryValue, ch,
                                 String.format(ASSERT_UPPER_LETTERS, entryValue));
@@ -393,8 +393,8 @@ public final class IbanUtil {
                 }
                 break;
             case c:
-                for(char ch: entryValue.toCharArray()) {
-                    if(!Character.isLetterOrDigit(ch)) {
+                for (char ch : entryValue.toCharArray()) {
+                    if (!Character.isLetterOrDigit(ch)) {
                         throw new IbanFormatException(BBAN_ONLY_DIGITS_OR_LETTERS,
                                 entry.getEntryType(), entryValue, ch,
                                 String.format(ASSERT_DIGITS_AND_LETTERS, entryValue));
@@ -402,8 +402,8 @@ public final class IbanUtil {
                 }
                 break;
             case n:
-                for(char ch: entryValue.toCharArray()) {
-                    if(!Character.isDigit(ch)) {
+                for (char ch : entryValue.toCharArray()) {
+                    if (!Character.isDigit(ch)) {
                         throw new IbanFormatException(BBAN_ONLY_DIGITS,
                                 entry.getEntryType(), entryValue, ch,
                                 String.format(ASSERT_DIGITS, entryValue));
@@ -453,13 +453,13 @@ public final class IbanUtil {
         final String bban = getBban(iban);
         final BbanStructure structure = getBbanStructure(iban);
         int bbanEntryOffset = 0;
-        for(final BbanStructureEntry entry : structure.getEntries()) {
+        for (final BbanStructureEntry entry : structure.getEntries()) {
             final int entryLength = entry.getLength();
             final String entryValue = bban.substring(bbanEntryOffset,
                     bbanEntryOffset + entryLength);
 
             bbanEntryOffset = bbanEntryOffset + entryLength;
-            if(entry.getEntryType() == entryType) {
+            if (entry.getEntryType() == entryType) {
                 return entryValue;
             }
         }


### PR DESCRIPTION
If there are multiple exceptions thrown by a method, each one should be defined with its own @throws tag in javadoc block