### PR TITLE
Improve Iban.Builder validation

### DIFF
--- a/src/main/java/org/iban4j/BicUtil.java
+++ b/src/main/java/org/iban4j/BicUtil.java
@@ -110,8 +110,7 @@ public class BicUtil {
         }
 
         if(CountryCode.getByCode(countryCode) == null) {
-            throw new UnsupportedCountryException(countryCode,
-                    "Country code is not supported.");
+            throw new UnsupportedCountryException(countryCode);
         }
     }
 

--- a/src/main/java/org/iban4j/Iban.java
+++ b/src/main/java/org/iban4j/Iban.java
@@ -204,7 +204,7 @@ public final class Iban {
     @Override
     public boolean equals(final Object obj) {
         if (obj instanceof Iban) {
-            return value.equals(((Iban)obj).value);
+            return value.equals(((Iban) obj).value);
         }
         return false;
     }
@@ -351,7 +351,7 @@ public final class Iban {
                 IllegalArgumentException, UnsupportedCountryException {
 
             // null checks
-            require(countryCode, bankCode, accountNumber);
+            checkRequiredFields();
 
             // iban is formatted with default check digit.
             final String formattedIban = formatIban();
@@ -394,11 +394,10 @@ public final class Iban {
             final BbanStructure structure = BbanStructure.forCountry(countryCode);
 
             if (structure == null) {
-                throw new UnsupportedCountryException(countryCode.toString(),
-                        "Country code is not supported.");
+                throw new UnsupportedCountryException(countryCode.toString());
             }
 
-            for(final BbanStructureEntry entry : structure.getEntries()) {
+            for (final BbanStructureEntry entry : structure.getEntries()) {
                 switch (entry.getEntryType()) {
                     case bank_code:
                         sb.append(bankCode);
@@ -437,23 +436,64 @@ public final class Iban {
             return sb.toString();
         }
 
-        private void require(final CountryCode countryCode,
-                             final String bankCode,
-                             final String accountNumber)
+        private void checkRequiredFields()
                 throws IbanFormatException {
-            if(countryCode == null) {
+
+            if (countryCode == null) {
                 throw new IbanFormatException(COUNTRY_CODE_NOT_NULL,
                         "countryCode is required; it cannot be null");
             }
 
-            if(bankCode == null) {
-                throw new IbanFormatException(BANK_CODE_NOT_NULL,
-                        "bankCode is required; it cannot be null");
+            final BbanStructure structure = BbanStructure.forCountry(countryCode);
+            if (structure == null) {
+                throw new UnsupportedCountryException(countryCode.toString());
             }
 
-            if(accountNumber == null) {
-                throw new IbanFormatException(ACCOUNT_NUMBER_NOT_NULL,
-                        "accountNumber is required; it cannot be null");
+            for (final BbanStructureEntry entry : structure.getEntries()) {
+                switch (entry.getEntryType()) {
+                    case bank_code:
+                        if (bankCode == null) {
+                            throw new IbanFormatException(BANK_CODE_NOT_NULL,
+                                    "bankCode is required; it cannot be null");
+                        }
+                        break;
+                    case branch_code:
+                        if (branchCode == null) {
+                            throw new IbanFormatException(BRANCH_CODE_NOT_NULL,
+                                    "branchCode is required; it cannot be null");
+                        }
+                        break;
+                    case account_number:
+                        if (accountNumber == null) {
+                            throw new IbanFormatException(ACCOUNT_NUMBER_NOT_NULL,
+                                    "accountNumber is required; it cannot be null");
+                        }
+                        break;
+                    case national_check_digit:
+                        if (nationalCheckDigit == null) {
+                            throw new IbanFormatException(NATIONAL_CHECK_DIGIT_NOT_NULL,
+                                    "nationalCheckDigit is required; it cannot be null");
+                        }
+                        break;
+                    case account_type:
+                        if (accountType == null) {
+                            throw new IbanFormatException(ACCOUNT_TYPE_NOT_NULL,
+                                    "accountType is required; it cannot be null");
+                        }
+                        break;
+                    case owner_account_number:
+                        if (ownerAccountType == null) {
+                            throw new IbanFormatException(OWNER_ACCOUNT_NUMBER_NOT_NULL,
+                                    "ownerAccountNumber is required; it cannot be null");
+                        }
+                        break;
+                    case identification_number:
+                        if (identificationNumber == null) {
+                            throw new IbanFormatException(IDENTIFICATION_NUMBER_NOT_NULL,
+                                    "identificationNumber is required; it cannot be null");
+                        }
+                        break;
+                }
             }
         }
 
@@ -461,11 +501,10 @@ public final class Iban {
             final BbanStructure structure = BbanStructure.forCountry(countryCode);
 
             if (structure == null) {
-                throw new UnsupportedCountryException(countryCode.toString(),
-                        "Country code is not supported.");
+                throw new UnsupportedCountryException(countryCode.toString());
             }
 
-            for(final BbanStructureEntry entry : structure.getEntries()) {
+            for (final BbanStructureEntry entry : structure.getEntries()) {
                 switch (entry.getEntryType()) {
                     case bank_code:
                         if (bankCode == null) {

--- a/src/main/java/org/iban4j/IbanFormatException.java
+++ b/src/main/java/org/iban4j/IbanFormatException.java
@@ -183,7 +183,12 @@ public class IbanFormatException extends Iban4jException {
         BBAN_ONLY_DIGITS_OR_LETTERS,
 
         BANK_CODE_NOT_NULL,
-        ACCOUNT_NUMBER_NOT_NULL
+        BRANCH_CODE_NOT_NULL,
+        ACCOUNT_NUMBER_NOT_NULL,
+        NATIONAL_CHECK_DIGIT_NOT_NULL,
+        ACCOUNT_TYPE_NOT_NULL,
+        OWNER_ACCOUNT_NUMBER_NOT_NULL,
+        IDENTIFICATION_NUMBER_NOT_NULL
 
     }
 }

--- a/src/main/java/org/iban4j/IbanUtil.java
+++ b/src/main/java/org/iban4j/IbanUtil.java
@@ -328,8 +328,7 @@ public final class IbanUtil {
         final BbanStructure structure = BbanStructure.forCountry(
                 CountryCode.getByCode(countryCode));
         if (structure == null) {
-            throw new UnsupportedCountryException(countryCode,
-                    "Country code is not supported.");
+            throw new UnsupportedCountryException(countryCode);
         }
     }
 

--- a/src/main/java/org/iban4j/UnsupportedCountryException.java
+++ b/src/main/java/org/iban4j/UnsupportedCountryException.java
@@ -22,56 +22,16 @@ public class UnsupportedCountryException extends Iban4jException {
 
     private static final long serialVersionUID = -3733353745417164234L;
 
-    private String countryCode;
+    private final String countryCode;
 
     /**
-     * Constructs a <code>UnsupportedCountryException</code> with no detail message and cause.
-     */
-    public UnsupportedCountryException() {
-        super();
-    }
-
-    /**
-     * Constructs a <code>UnsupportedCountryException</code> with the
-     * specified detail message.
-     *
-     * @param s the detail message.
-     */
-    public UnsupportedCountryException(final String s) {
-        super(s);
-    }
-
-    /**
-     * Constructs a <code>UnsupportedCountryException</code> with the
-     * specified country code and detail message.
+     * Constructs a <code>UnsupportedCountryException</code> with the specified country code.
      *
      * @param countryCode the country code.
-     * @param s the detail message.
      */
-    public UnsupportedCountryException(String countryCode, final String s) {
-        super(s);
+    public UnsupportedCountryException(String countryCode) {
+        super(String.format("Country code '%s' is not supported.", countryCode));
         this.countryCode = countryCode;
-    }
-
-    /**
-     * Constructs a <code>UnsupportedCountryException</code> with the
-     * specified detail message and cause.
-     *
-     * @param s the detail message.
-     * @param t the cause.
-     */
-    public UnsupportedCountryException(final String s, final Throwable t) {
-        super(s, t);
-    }
-
-    /**
-     * Constructs a <code>UnsupportedCountryException</code> with the
-     * specified cause.
-     *
-     * @param t the cause.
-     */
-    public UnsupportedCountryException(final Throwable t) {
-        super(t);
     }
 
     public String getCountryCode() {

--- a/src/test/java/org/iban4j/IbanTest.java
+++ b/src/test/java/org/iban4j/IbanTest.java
@@ -22,9 +22,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Collection;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 
@@ -344,8 +342,17 @@ public class IbanTest {
         @Test(expected = IbanFormatException.class)
         public void ibanConstructionWithoutBankCodeShouldThrowException() {
             new Iban.Builder()
-                    .countryCode(CountryCode.AM)
+                    .countryCode(CountryCode.AT)
                     .branchCode("2030")
+                    .accountNumber("200359100100")
+                    .build();
+        }
+
+        @Test(expected = IbanFormatException.class)
+        public void ibanConstructionWithoutBranchCodeShouldThrowException() {
+            new Iban.Builder()
+                    .countryCode(CountryCode.SC)
+                    .bankCode("0001")
                     .accountNumber("200359100100")
                     .build();
         }
@@ -353,9 +360,50 @@ public class IbanTest {
         @Test(expected = IbanFormatException.class)
         public void ibanConstructionWithoutAccountNumberShouldThrowException() {
             new Iban.Builder()
-                    .countryCode(CountryCode.AM)
+                    .countryCode(CountryCode.AT)
                     .bankCode("0001")
                     .branchCode("2030")
+                    .build();
+        }
+
+        @Test(expected = IbanFormatException.class)
+        public void ibanConstructionWithoutNationalCheckDigitShouldThrowException() {
+            new Iban.Builder()
+                    .countryCode(CountryCode.SM)
+                    .bankCode("0001")
+                    .branchCode("2030")
+                    .accountNumber("200359100100")
+                    .build();
+        }
+
+        @Test(expected = IbanFormatException.class)
+        public void ibanConstructionWithoutAccountTypeShouldThrowException() {
+            new Iban.Builder()
+                    .countryCode(CountryCode.SC)
+                    .bankCode("0001")
+                    .branchCode("2030")
+                    .accountNumber("200359100100")
+                    .build();
+        }
+
+        @Test(expected = IbanFormatException.class)
+        public void ibanConstructionWithoutOwnerAccountNumberShouldThrowException() {
+            new Iban.Builder()
+                    .countryCode(CountryCode.BR)
+                    .bankCode("0001")
+                    .branchCode("2030")
+                    .accountNumber("200359100100")
+                    .accountType("00")
+                    .build();
+        }
+
+        @Test(expected = IbanFormatException.class)
+        public void ibanConstructionWithoutIdentificationNumberShouldThrowException() {
+            new Iban.Builder()
+                    .countryCode(CountryCode.IS)
+                    .bankCode("0001")
+                    .branchCode("2030")
+                    .accountNumber("200359100100")
                     .build();
         }
 
@@ -387,7 +435,7 @@ public class IbanTest {
         }
 
         @Test
-        public void ibanContructionRandom() {
+        public void ibanConstructionRandom() {
             for (int i = 0; i < 100; i++) {
                 new Iban.Builder().buildRandom();
                 Iban.random();
@@ -395,7 +443,7 @@ public class IbanTest {
         }
 
         @Test
-        public void ibanContructionRandomAcctRetainsSpecifiedCountry() {
+        public void ibanConstructionRandomAcctRetainsSpecifiedCountry() {
             Iban iban = new Iban.Builder().countryCode(CountryCode.AT).buildRandom();
             assertThat(iban.getCountryCode(), is(equalTo(CountryCode.AT)));
 
@@ -404,7 +452,7 @@ public class IbanTest {
         }
 
         @Test
-        public void ibanContructionRandomRetainsSpecifiedBankCode() {
+        public void ibanConstructionRandomRetainsSpecifiedBankCode() {
             Iban iban = new Iban.Builder()
                     .countryCode(CountryCode.AT)
                     .bankCode("12345")
@@ -413,7 +461,7 @@ public class IbanTest {
         }
 
         @Test
-        public void ibanContructionRandomDoesNotOverwriteBankAccount() {
+        public void ibanConstructionRandomDoesNotOverwriteBankAccount() {
             Iban iban = new Iban.Builder()
                     .countryCode(CountryCode.AT)
                     .accountNumber("12345678901")
@@ -422,7 +470,7 @@ public class IbanTest {
         }
 
         @Test
-        public void ibanContructionRandomDoesNotOverwriteBranchCode() {
+        public void ibanConstructionRandomDoesNotOverwriteBranchCode() {
             Iban iban = new Iban.Builder()
                     .countryCode(CountryCode.AL)
                     .branchCode("1234")
@@ -431,7 +479,7 @@ public class IbanTest {
         }
 
         @Test
-        public void ibanContructionRandomDoesNotOverwriteNationalCheckDigit() {
+        public void ibanConstructionRandomDoesNotOverwriteNationalCheckDigit() {
             Iban iban = new Iban.Builder()
                     .countryCode(CountryCode.AL)
                     .nationalCheckDigit("1")
@@ -440,7 +488,7 @@ public class IbanTest {
         }
 
         @Test
-        public void ibanContructionRandomDoesNotOverwriteAccountType() {
+        public void ibanConstructionRandomDoesNotOverwriteAccountType() {
             Iban iban = new Iban.Builder()
                     .countryCode(CountryCode.BR)
                     .accountType("A")
@@ -449,7 +497,7 @@ public class IbanTest {
         }
 
         @Test
-        public void ibanContructionRandomDoesNotOverwriteOwnerAccountType() {
+        public void ibanConstructionRandomDoesNotOverwriteOwnerAccountType() {
             Iban iban = new Iban.Builder()
                     .countryCode(CountryCode.BR)
                     .ownerAccountType("C")
@@ -458,7 +506,7 @@ public class IbanTest {
         }
 
         @Test
-        public void ibanContructionRandomDoesNotOverwriteIdentificationNumber() {
+        public void ibanConstructionRandomDoesNotOverwriteIdentificationNumber() {
             Iban iban = new Iban.Builder()
                     .countryCode(CountryCode.IS)
                     .identificationNumber("1234567890")


### PR DESCRIPTION
I extended the Iban.Builder validation to be based on BbanStructure of the passed country.
If some entry is missing, the validation will throw an exception with the missing field. This makes sense because the BbanStructure will be used in the next steps `formatIban -> formatBban` and there is no reason to go to this step if the given data is not enough to generate a valid IBAN.

Changes:
- extended validation
- simplified `UnsupportedCountryException` to expect just the country code. The error message was moved to the exception itself and is based on the passed country code.

Related issues:
- https://github.com/arturmkrtchyan/iban4j/issues/47
- https://github.com/arturmkrtchyan/iban4j/issues/71

@hajk1 This PR also relates to your proposed fix in: https://github.com/arturmkrtchyan/iban4j/pull/75