### PR TITLE
Add support for extension points

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.iban4j</groupId>
     <artifactId>iban4j</artifactId>
-    <version>3.2.3-RELEASE</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>iban4j</name>

--- a/src/main/java/org/iban4j/bban/BbanStructure.java
+++ b/src/main/java/org/iban4j/bban/BbanStructure.java
@@ -15,9 +15,15 @@
  */
 package org.iban4j.bban;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.TreeSet;
 import org.iban4j.CountryCode;
-
-import java.util.*;
+import org.iban4j.spi.BbanStructureProvider;
 
 
 /**
@@ -25,478 +31,16 @@ import java.util.*;
  */
 public class BbanStructure {
 
-    private final BbanStructureEntry[] entries;
-
-    private BbanStructure(final BbanStructureEntry... entries) {
-        this.entries = entries;
-    }
-
-
-    private static final EnumMap<CountryCode, BbanStructure> structures;
-
-    /* French sub-territories may use their own country code (BL,RE,NC,...) or FR for their IBAN. Structure is the same, only the IBAN checksum differ. */
-    private final static BbanStructure FRENCH_STRUCTURE = new BbanStructure(
-        BbanStructureEntry.bankCode(5, 'n'),
-        BbanStructureEntry.branchCode(5, 'n'),
-        BbanStructureEntry.accountNumber(11, 'c'),
-        BbanStructureEntry.nationalCheckDigit(2, 'n'));
+    private static final Iterable<BbanStructureProvider> providers;
 
     static {
-        structures = new EnumMap<CountryCode, BbanStructure>(CountryCode.class);
+        providers = ServiceLoader.load(BbanStructureProvider.class);
+    }
 
-        structures.put(CountryCode.AL,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(1, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'c')));
+    private final BbanStructureEntry[] entries;
 
-        structures.put(CountryCode.AD,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(12, 'c')));
-
-        structures.put(CountryCode.AT,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(5, 'n'),
-                        BbanStructureEntry.accountNumber(11, 'n')));
-
-
-        structures.put(CountryCode.AZ,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(20, 'c')));
-
-        structures.put(CountryCode.BH,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(14, 'c')));
-
-        structures.put(CountryCode.BE,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(7, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.BA,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.branchCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(8, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.BR,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(8, 'n'),
-                        BbanStructureEntry.branchCode(5, 'n'),
-                        BbanStructureEntry.accountNumber(10, 'n'),
-                        BbanStructureEntry.accountType(1, 'a'),
-                        BbanStructureEntry.ownerAccountNumber(1, 'c')));
-
-        structures.put(CountryCode.BG,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.accountType(2, 'n'),
-                        BbanStructureEntry.accountNumber(8, 'c')));
-
-        structures.put(CountryCode.BL, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.BY,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'c'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'c')));
-
-        structures.put(CountryCode.CR,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(14, 'n')));
-
-        structures.put(CountryCode.DE,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(8, 'n'),
-                        BbanStructureEntry.accountNumber(10, 'n')));
-
-        structures.put(CountryCode.HR,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(7, 'n'),
-                        BbanStructureEntry.accountNumber(10, 'n')));
-
-        structures.put(CountryCode.CY,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.branchCode(5, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'c')));
-
-        structures.put(CountryCode.CZ,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'n')));
-
-        structures.put(CountryCode.DK,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(10, 'n')));
-
-        structures.put(CountryCode.DO,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'c'),
-                        BbanStructureEntry.accountNumber(20, 'n')));
-
-        structures.put(CountryCode.EE,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(2, 'n'),
-                        BbanStructureEntry.branchCode(2, 'n'),
-                        BbanStructureEntry.accountNumber(11, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(1, 'n')));
-
-        structures.put(CountryCode.FO,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(9, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(1, 'n')));
-
-        structures.put(CountryCode.FI,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(6, 'n'),
-                        BbanStructureEntry.accountNumber(7, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(1, 'n')));
-
-        structures.put(CountryCode.FR, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.GE,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(2, 'a'),
-                        BbanStructureEntry.accountNumber(16, 'n')));
-
-        structures.put(CountryCode.GF, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.GI,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(15, 'c')));
-
-        structures.put(CountryCode.GL,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(10, 'n')));
-
-        structures.put(CountryCode.GP, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.GR,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'c')));
-
-        structures.put(CountryCode.GT,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'c'),
-                        BbanStructureEntry.accountNumber(20, 'c')));
-
-        structures.put(CountryCode.HU,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(1, 'n')));
-
-        structures.put(CountryCode.IS,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.branchCode(2, 'n'),
-                        BbanStructureEntry.accountNumber(6, 'n'),
-                        BbanStructureEntry.identificationNumber(10, 'n')));
-
-        structures.put(CountryCode.IE,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.branchCode(6, 'n'),
-                        BbanStructureEntry.accountNumber(8, 'n')));
-
-        structures.put(CountryCode.IL,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.branchCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(13, 'n')));
-
-        structures.put(CountryCode.IR,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(19, 'n')));
-
-        structures.put(CountryCode.IT,
-                new BbanStructure(
-                        BbanStructureEntry.nationalCheckDigit(1, 'a'),
-                        BbanStructureEntry.bankCode(5, 'n'),
-                        BbanStructureEntry.branchCode(5, 'n'),
-                        BbanStructureEntry.accountNumber(12, 'c')));
-
-        structures.put(CountryCode.JO,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(18, 'c')));
-
-        structures.put(CountryCode.KZ,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(13, 'c')));
-
-        structures.put(CountryCode.KW,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(22, 'c')));
-
-        structures.put(CountryCode.LC,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(24, 'c')));
-
-        structures.put(CountryCode.LV,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(13, 'c')));
-
-        structures.put(CountryCode.LB,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(20, 'c')));
-
-        structures.put(CountryCode.LI,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(5, 'n'),
-                        BbanStructureEntry.accountNumber(12, 'c')));
-
-        structures.put(CountryCode.LT,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(5, 'n'),
-                        BbanStructureEntry.accountNumber(11, 'n')));
-
-        structures.put(CountryCode.LU,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(13, 'c')));
-
-        structures.put(CountryCode.MF, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.MK,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(10, 'c'),
-                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.MT,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.branchCode(5, 'n'),
-                        BbanStructureEntry.accountNumber(18, 'c')));
-
-        structures.put(CountryCode.MR,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(5, 'n'),
-                        BbanStructureEntry.branchCode(5, 'n'),
-                        BbanStructureEntry.accountNumber(11, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.MU,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(6, 'c'),
-                        BbanStructureEntry.branchCode(2, 'n'),
-                        BbanStructureEntry.accountNumber(18, 'c')));
-
-        structures.put(CountryCode.MD,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(2, 'c'),
-                        BbanStructureEntry.accountNumber(18, 'c')));
-
-        structures.put(CountryCode.MC, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.ME,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(13, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.MQ, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.NC, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.NL,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(10, 'n')));
-
-        structures.put(CountryCode.NO,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(6, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(1, 'n')));
-
-        structures.put(CountryCode.PF, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.PK,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'c'),
-                        BbanStructureEntry.accountNumber(16, 'n')));
-
-        structures.put(CountryCode.PM, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.PS,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(21, 'c')));
-
-        structures.put(CountryCode.PL,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(1, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'n')));
-
-        structures.put(CountryCode.PT,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(11, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.RE, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.RO,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(16, 'c')));
-
-        structures.put(CountryCode.QA,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(21, 'c')));
-
-        structures.put(CountryCode.SC,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'n'),
-                        BbanStructureEntry.accountType(3, 'a')));
-
-        structures.put(CountryCode.SM,
-                new BbanStructure(
-                        BbanStructureEntry.nationalCheckDigit(1, 'a'),
-                        BbanStructureEntry.bankCode(5, 'n'),
-                        BbanStructureEntry.branchCode(5, 'n'),
-                        BbanStructureEntry.accountNumber(12, 'c')));
-
-        structures.put(CountryCode.ST,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(13, 'n')));
-
-        structures.put(CountryCode.SA,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(2, 'n'),
-                        BbanStructureEntry.accountNumber(18, 'c')));
-
-        structures.put(CountryCode.RS,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(13, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.SK,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'n')));
-
-        structures.put(CountryCode.SI,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(2, 'n'),
-                        BbanStructureEntry.branchCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(8, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.SV,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(20, 'n')));
-
-        structures.put(CountryCode.ES,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'n'),
-                        BbanStructureEntry.branchCode(4, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(2, 'n'),
-                        BbanStructureEntry.accountNumber(10, 'n')));
-
-        structures.put(CountryCode.SE,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(17, 'n')));
-
-        structures.put(CountryCode.CH,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(5, 'n'),
-                        BbanStructureEntry.accountNumber(12, 'c')));
-
-        structures.put(CountryCode.TF, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.TN,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(2, 'n'),
-                        BbanStructureEntry.branchCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(15, 'c')));
-
-        structures.put(CountryCode.TR,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(5, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(1, 'c'),
-                        BbanStructureEntry.accountNumber(16, 'c')));
-
-        structures.put(CountryCode.UA,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(6, 'n'),
-                        BbanStructureEntry.accountNumber(19, 'n')));
-
-        structures.put(CountryCode.GB,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.branchCode(6, 'n'),
-                        BbanStructureEntry.accountNumber(8, 'n')));
-
-        structures.put(CountryCode.AE,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(16, 'c')));
-
-        structures.put(CountryCode.VA,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(15, 'n')));
-
-        structures.put(CountryCode.VG,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.accountNumber(16, 'n')));
-
-        structures.put(CountryCode.TL,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(3, 'n'),
-                        BbanStructureEntry.accountNumber(14, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.WF, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.XK,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(2, 'n'),
-                        BbanStructureEntry.branchCode(2, 'n'),
-                        BbanStructureEntry.accountNumber(10, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.YT, BbanStructure.FRENCH_STRUCTURE);
-
+    public BbanStructure(final BbanStructureEntry... entries) {
+        this.entries = entries;
     }
 
     /**
@@ -504,7 +48,12 @@ public class BbanStructure {
      * @return BbanStructure for specified country or null if country is not supported.
      */
     public static BbanStructure forCountry(final CountryCode countryCode) {
-        return structures.get(countryCode);
+        for (BbanStructureProvider provider : providers) {
+            if (provider.supportsCountry(countryCode)) {
+                return provider.forCountry(countryCode);
+            }
+        }
+        return null;
     }
 
     public List<BbanStructureEntry> getEntries() {
@@ -512,9 +61,11 @@ public class BbanStructure {
     }
 
     public static List<CountryCode> supportedCountries() {
-        final List<CountryCode> countryCodes = new ArrayList<CountryCode>(structures.size());
-        countryCodes.addAll(structures.keySet());
-        return Collections.unmodifiableList(countryCodes);
+        final Set<CountryCode> countryCodes = new TreeSet<>();
+        for (BbanStructureProvider provider : providers) {
+            countryCodes.addAll(provider.supportedCountries());
+        }
+        return Collections.unmodifiableList(new ArrayList<>(countryCodes));
     }
 
     /**

--- a/src/main/java/org/iban4j/spi/BbanStructureProvider.java
+++ b/src/main/java/org/iban4j/spi/BbanStructureProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 L&aacute;szl&oacute;-R&oacute;bert Albert (robert@albertlr.ro)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.iban4j.spi;
+
+import java.util.Collection;
+import org.iban4j.CountryCode;
+import org.iban4j.bban.BbanStructure;
+
+/**
+ * SPI support for adding and extending the library to support additional {@link BbanStructure}s for countries that does
+ * not yet support it.
+ *
+ * @author L&aacute;szl&oacute;-R&oacute;bert Albert (robert@albertlr.ro)
+ */
+public interface BbanStructureProvider {
+
+    /**
+     * Determine if this provider supports a given country.
+     *
+     * @param countryCode the country code.
+     * @return Returns <tt>true</tt> if and only if this provider supports {@link BbanStructure} for a given country.
+     */
+    boolean supportsCountry(final CountryCode countryCode);
+
+    /**
+     * @param countryCode the country code.
+     * @return BbanStructure for specified country or null if country is not supported.
+     */
+    BbanStructure forCountry(final CountryCode countryCode);
+
+    Collection<CountryCode> supportedCountries();
+}

--- a/src/main/java/org/iban4j/spi/internal/DefaultBbanStructureProvider.java
+++ b/src/main/java/org/iban4j/spi/internal/DefaultBbanStructureProvider.java
@@ -1,0 +1,512 @@
+/*
+ * Copyright 2021 L&aacute;szl&oacute;-R&oacute;bert Albert (robert@albertlr.ro)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.iban4j.spi.internal;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import org.iban4j.CountryCode;
+import org.iban4j.bban.BbanStructure;
+import org.iban4j.bban.BbanStructureEntry;
+import org.iban4j.spi.BbanStructureProvider;
+
+/**
+ * The default implementation holding all known {@link BbanStructure}s. It is equivalent with the original implementation hold in {@link BbanStructure}.
+ * @author L&aacute;szl&oacute;-R&oacute;bert Albert (robert@albertlr.ro)
+ */
+public class DefaultBbanStructureProvider implements BbanStructureProvider {
+    private static final EnumMap<CountryCode, BbanStructure> structures;
+
+    /* French sub-territories may use their own country code (BL,RE,NC,...) or FR for their IBAN. Structure is the same, only the IBAN checksum differ. */
+    private final static BbanStructure FRENCH_STRUCTURE = new BbanStructure(
+            BbanStructureEntry.bankCode(5, 'n'),
+            BbanStructureEntry.branchCode(5, 'n'),
+            BbanStructureEntry.accountNumber(11, 'c'),
+            BbanStructureEntry.nationalCheckDigit(2, 'n'));
+
+    static {
+        structures = new EnumMap<CountryCode, BbanStructure>(CountryCode.class);
+
+        structures.put(CountryCode.AL,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(1, 'n'),
+                        BbanStructureEntry.accountNumber(16, 'c')));
+
+        structures.put(CountryCode.AD,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(12, 'c')));
+
+        structures.put(CountryCode.AT,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(5, 'n'),
+                        BbanStructureEntry.accountNumber(11, 'n')));
+
+
+        structures.put(CountryCode.AZ,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(20, 'c')));
+
+        structures.put(CountryCode.BH,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(14, 'c')));
+
+        structures.put(CountryCode.BE,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(7, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
+
+        structures.put(CountryCode.BA,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.branchCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(8, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
+
+        structures.put(CountryCode.BR,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(8, 'n'),
+                        BbanStructureEntry.branchCode(5, 'n'),
+                        BbanStructureEntry.accountNumber(10, 'n'),
+                        BbanStructureEntry.accountType(1, 'a'),
+                        BbanStructureEntry.ownerAccountNumber(1, 'c')));
+
+        structures.put(CountryCode.BG,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.accountType(2, 'n'),
+                        BbanStructureEntry.accountNumber(8, 'c')));
+
+        structures.put(CountryCode.BL, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.BY,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'c'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(16, 'c')));
+
+        structures.put(CountryCode.CR,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(14, 'n')));
+
+        structures.put(CountryCode.DE,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(8, 'n'),
+                        BbanStructureEntry.accountNumber(10, 'n')));
+
+        structures.put(CountryCode.HR,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(7, 'n'),
+                        BbanStructureEntry.accountNumber(10, 'n')));
+
+        structures.put(CountryCode.CY,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.branchCode(5, 'n'),
+                        BbanStructureEntry.accountNumber(16, 'c')));
+
+        structures.put(CountryCode.CZ,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(16, 'n')));
+
+        structures.put(CountryCode.DK,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(10, 'n')));
+
+        structures.put(CountryCode.DO,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'c'),
+                        BbanStructureEntry.accountNumber(20, 'n')));
+
+        structures.put(CountryCode.EE,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(2, 'n'),
+                        BbanStructureEntry.branchCode(2, 'n'),
+                        BbanStructureEntry.accountNumber(11, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(1, 'n')));
+
+        structures.put(CountryCode.FO,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(9, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(1, 'n')));
+
+        structures.put(CountryCode.FI,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(6, 'n'),
+                        BbanStructureEntry.accountNumber(7, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(1, 'n')));
+
+        structures.put(CountryCode.FR, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.GE,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(2, 'a'),
+                        BbanStructureEntry.accountNumber(16, 'n')));
+
+        structures.put(CountryCode.GF, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.GI,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(15, 'c')));
+
+        structures.put(CountryCode.GL,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(10, 'n')));
+
+        structures.put(CountryCode.GP, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.GR,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(16, 'c')));
+
+        structures.put(CountryCode.GT,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'c'),
+                        BbanStructureEntry.accountNumber(20, 'c')));
+
+        structures.put(CountryCode.HU,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(16, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(1, 'n')));
+
+        structures.put(CountryCode.IS,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.branchCode(2, 'n'),
+                        BbanStructureEntry.accountNumber(6, 'n'),
+                        BbanStructureEntry.identificationNumber(10, 'n')));
+
+        structures.put(CountryCode.IE,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.branchCode(6, 'n'),
+                        BbanStructureEntry.accountNumber(8, 'n')));
+
+        structures.put(CountryCode.IL,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.branchCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(13, 'n')));
+
+        structures.put(CountryCode.IR,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(19, 'n')));
+
+        structures.put(CountryCode.IT,
+                new BbanStructure(
+                        BbanStructureEntry.nationalCheckDigit(1, 'a'),
+                        BbanStructureEntry.bankCode(5, 'n'),
+                        BbanStructureEntry.branchCode(5, 'n'),
+                        BbanStructureEntry.accountNumber(12, 'c')));
+
+        structures.put(CountryCode.JO,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(18, 'c')));
+
+        structures.put(CountryCode.KZ,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(13, 'c')));
+
+        structures.put(CountryCode.KW,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(22, 'c')));
+
+        structures.put(CountryCode.LC,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(24, 'c')));
+
+        structures.put(CountryCode.LV,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(13, 'c')));
+
+        structures.put(CountryCode.LB,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(20, 'c')));
+
+        structures.put(CountryCode.LI,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(5, 'n'),
+                        BbanStructureEntry.accountNumber(12, 'c')));
+
+        structures.put(CountryCode.LT,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(5, 'n'),
+                        BbanStructureEntry.accountNumber(11, 'n')));
+
+        structures.put(CountryCode.LU,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(13, 'c')));
+
+        structures.put(CountryCode.MF, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.MK,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(10, 'c'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
+
+        structures.put(CountryCode.MT,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.branchCode(5, 'n'),
+                        BbanStructureEntry.accountNumber(18, 'c')));
+
+        structures.put(CountryCode.MR,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(5, 'n'),
+                        BbanStructureEntry.branchCode(5, 'n'),
+                        BbanStructureEntry.accountNumber(11, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
+
+        structures.put(CountryCode.MU,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(6, 'c'),
+                        BbanStructureEntry.branchCode(2, 'n'),
+                        BbanStructureEntry.accountNumber(18, 'c')));
+
+        structures.put(CountryCode.MD,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(2, 'c'),
+                        BbanStructureEntry.accountNumber(18, 'c')));
+
+        structures.put(CountryCode.MC, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.ME,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(13, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
+
+        structures.put(CountryCode.MQ, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.NC, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.NL,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(10, 'n')));
+
+        structures.put(CountryCode.NO,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(6, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(1, 'n')));
+
+        structures.put(CountryCode.PF, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.PK,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'c'),
+                        BbanStructureEntry.accountNumber(16, 'n')));
+
+        structures.put(CountryCode.PM, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.PS,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(21, 'c')));
+
+        structures.put(CountryCode.PL,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(1, 'n'),
+                        BbanStructureEntry.accountNumber(16, 'n')));
+
+        structures.put(CountryCode.PT,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(11, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
+
+        structures.put(CountryCode.RE, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.RO,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(16, 'c')));
+
+        structures.put(CountryCode.QA,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(21, 'c')));
+
+        structures.put(CountryCode.SC,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(16, 'n'),
+                        BbanStructureEntry.accountType(3, 'a')));
+
+        structures.put(CountryCode.SM,
+                new BbanStructure(
+                        BbanStructureEntry.nationalCheckDigit(1, 'a'),
+                        BbanStructureEntry.bankCode(5, 'n'),
+                        BbanStructureEntry.branchCode(5, 'n'),
+                        BbanStructureEntry.accountNumber(12, 'c')));
+
+        structures.put(CountryCode.ST,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(13, 'n')));
+
+        structures.put(CountryCode.SA,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(2, 'n'),
+                        BbanStructureEntry.accountNumber(18, 'c')));
+
+        structures.put(CountryCode.RS,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(13, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
+
+        structures.put(CountryCode.SK,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.accountNumber(16, 'n')));
+
+        structures.put(CountryCode.SI,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(2, 'n'),
+                        BbanStructureEntry.branchCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(8, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
+
+        structures.put(CountryCode.SV,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(20, 'n')));
+
+        structures.put(CountryCode.ES,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'n'),
+                        BbanStructureEntry.branchCode(4, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n'),
+                        BbanStructureEntry.accountNumber(10, 'n')));
+
+        structures.put(CountryCode.SE,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(17, 'n')));
+
+        structures.put(CountryCode.CH,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(5, 'n'),
+                        BbanStructureEntry.accountNumber(12, 'c')));
+
+        structures.put(CountryCode.TF, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.TN,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(2, 'n'),
+                        BbanStructureEntry.branchCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(15, 'c')));
+
+        structures.put(CountryCode.TR,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(5, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(1, 'c'),
+                        BbanStructureEntry.accountNumber(16, 'c')));
+
+        structures.put(CountryCode.UA,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(6, 'n'),
+                        BbanStructureEntry.accountNumber(19, 'n')));
+
+        structures.put(CountryCode.GB,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.branchCode(6, 'n'),
+                        BbanStructureEntry.accountNumber(8, 'n')));
+
+        structures.put(CountryCode.AE,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(16, 'c')));
+
+        structures.put(CountryCode.VA,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(15, 'n')));
+
+        structures.put(CountryCode.VG,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(4, 'a'),
+                        BbanStructureEntry.accountNumber(16, 'n')));
+
+        structures.put(CountryCode.TL,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(3, 'n'),
+                        BbanStructureEntry.accountNumber(14, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
+
+        structures.put(CountryCode.WF, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+
+        structures.put(CountryCode.XK,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(2, 'n'),
+                        BbanStructureEntry.branchCode(2, 'n'),
+                        BbanStructureEntry.accountNumber(10, 'n'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
+
+        structures.put(CountryCode.YT, DefaultBbanStructureProvider.FRENCH_STRUCTURE);
+    }
+
+    @Override
+    public boolean supportsCountry(CountryCode countryCode) {
+        return structures.containsKey(countryCode);
+    }
+
+    @Override
+    public BbanStructure forCountry(CountryCode countryCode) {
+        return structures.get(countryCode);
+    }
+
+    @Override
+    public Collection<CountryCode> supportedCountries() {
+        return Collections.unmodifiableCollection(structures.keySet());
+    }
+}

--- a/src/main/resources/META-INF/services/org.iban4j.spi.BbanStructureProvider
+++ b/src/main/resources/META-INF/services/org.iban4j.spi.BbanStructureProvider
@@ -1,0 +1,1 @@
+org.iban4j.spi.internal.DefaultBbanStructureProvider

--- a/src/test/java/org/iban4j/spi/IraqBbanStructureProvider.java
+++ b/src/test/java/org/iban4j/spi/IraqBbanStructureProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 L&aacute;szl&oacute;-R&oacute;bert Albert (robert@albertlr.ro)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.iban4j.spi;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.iban4j.CountryCode;
+import org.iban4j.bban.BbanStructure;
+import org.iban4j.bban.BbanStructureEntry;
+
+/**
+ * Example {@link BbanStructure} provider for Iraq.
+ *
+ * @author L&aacute;szl&oacute;-R&oacute;bert Albert (robert@albertlr.ro)
+ * @see <a href="https://www.swift.com/resource/iban-registry-pdf">SWIFT IBAN Registry</a>
+ */
+public class IraqBbanStructureProvider implements BbanStructureProvider {
+    @Override
+    public boolean supportsCountry(CountryCode countryCode) {
+        return CountryCode.IQ == countryCode;
+    }
+
+    @Override
+    public BbanStructure forCountry(CountryCode countryCode) {
+        if (CountryCode.IQ == countryCode) {
+            // '4!a3!n12!n'
+            return
+                    new BbanStructure(
+                            BbanStructureEntry.bankCode(4, 'a'),
+                            BbanStructureEntry.branchCode(3, 'n'),
+                            BbanStructureEntry.accountNumber(12, 'n')
+                    );
+        }
+        return null;
+    }
+
+    @Override
+    public Collection<CountryCode> supportedCountries() {
+        return Arrays.asList(CountryCode.IQ);
+    }
+}

--- a/src/test/java/org/iban4j/spi/IraqBbanStructureTest.java
+++ b/src/test/java/org/iban4j/spi/IraqBbanStructureTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 L&aacute;szl&oacute;-R&oacute;bert Albert (robert@albertlr.ro)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.iban4j.spi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ServiceLoader;
+import org.iban4j.CountryCode;
+import org.iban4j.IbanUtil;
+import org.iban4j.UnsupportedCountryException;
+import org.junit.Test;
+
+/**
+ * Testing an extension point implementing the Iraq {@link org.iban4j.bban.BbanStructure}.
+ *
+ * @author L&aacute;szl&oacute;-R&oacute;bert Albert (robert@albertlr.ro)
+ * @see IraqBbanStructureProvider
+ */
+public class IraqBbanStructureTest {
+
+    @Test
+    public void shouldValidateAnIbanFromIraq() {
+        // if you remove or rename the org.iban4j.spi.BbanStructureProvider from src/test/resources/META-INF/services
+        // this test will fail
+
+        try {
+            IbanUtil.validate("IQ98NBIQ850123456789012");
+        } catch (UnsupportedCountryException exception) {
+            // expect to fail with this error if IraqBbanStructureProvider is not present
+            fail(exception.getMessage());
+        } catch (Exception exception) {
+            // not expected at all
+            fail("Not expected: " + exception.getMessage());
+        }
+    }
+
+    @Test
+    public void shouldSeeIraqBbanStructureProviderThroughSpi() {
+        ServiceLoader<BbanStructureProvider> providers = ServiceLoader.load(BbanStructureProvider.class);
+
+        boolean tested = false;
+        for (BbanStructureProvider provider : providers) {
+            if (provider instanceof IraqBbanStructureProvider) {
+                assertEquals(1, provider.supportedCountries().size());
+                assertEquals(CountryCode.IQ, provider.supportedCountries().iterator().next());
+                for (CountryCode countryCode : CountryCode.values()) {
+                    switch (countryCode) {
+                        case IQ:
+                            assertTrue(provider.supportsCountry(CountryCode.IQ));
+                            break;
+                        default:
+                            assertFalse(provider.supportsCountry(countryCode));
+                            break;
+                    }
+
+                }
+                tested = true;
+            }
+        }
+        assertTrue("IraqBbanStructureProvider not loaded", tested);
+    }
+}

--- a/src/test/java/org/iban4j/spi/IraqBbanStructureTest.java
+++ b/src/test/java/org/iban4j/spi/IraqBbanStructureTest.java
@@ -24,6 +24,7 @@ import java.util.ServiceLoader;
 import org.iban4j.CountryCode;
 import org.iban4j.IbanUtil;
 import org.iban4j.UnsupportedCountryException;
+import org.iban4j.bban.BbanStructure;
 import org.junit.Test;
 
 /**
@@ -74,5 +75,10 @@ public class IraqBbanStructureTest {
             }
         }
         assertTrue("IraqBbanStructureProvider not loaded", tested);
+    }
+
+    @Test
+    public void shouldHaveIraqAsSupportedCountry() {
+        assertTrue(BbanStructure.supportedCountries().contains(CountryCode.IQ));
     }
 }

--- a/src/test/resources/META-INF/services/org.iban4j.spi.BbanStructureProvider
+++ b/src/test/resources/META-INF/services/org.iban4j.spi.BbanStructureProvider
@@ -1,0 +1,2 @@
+# comment below line to test that if it is not provided the IraqBbanStructureTest would fail
+org.iban4j.spi.IraqBbanStructureProvider


### PR DESCRIPTION
The current implementation is not flexible enough. If a given country was not implemented or not supported at the time of writing, without a code change there is no way to add support for a new country that now do support IBAN accounts.

In my example I used Iraq, which is not implemented in the code, and cannot be extended, only with a code change and a new release, which might be cumbersome for the lifecycle of the project that you are working on.

So I added an extension point through [SPI](https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html), where additional `BbanStructure`s can be provided. 

This, now, can be done by providing an implementation of `BbanStructureProvider`, and add the fully qualified name of your implementation in `src/main/resources/META-INF/services/org.iban4j.spi.BbanStructureProvider` of your project.

The project currently have one implementation, that is `DefaultBbanStructureProvider`, which holds all the `BbanStructure`s that were there before this change, and a test implementation of Iraq.
