### PR TITLE
upgrade jacoco maven plugin 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.2.201409121644</version>
+                <version>0.8.7</version>
                 <executions>
                     <!--
                        Prepares the property pointing to the JaCoCo runtime agent which


### PR DESCRIPTION
In order to support Java versions higher than 8