### PR TITLE
adding GB and FI sub-territories support

### DIFF
--- a/src/main/java/org/iban4j/bban/BbanStructure.java
+++ b/src/main/java/org/iban4j/bban/BbanStructure.java
@@ -41,6 +41,16 @@ public class BbanStructure {
         BbanStructureEntry.accountNumber(11, 'c'),
         BbanStructureEntry.nationalCheckDigit(2, 'n'));
 
+    private final static BbanStructure UNITED_KINGDOM_STRUCTURE = new BbanStructure(
+        BbanStructureEntry.bankCode(4, 'a'),
+        BbanStructureEntry.branchCode(6, 'n'),
+        BbanStructureEntry.accountNumber(8, 'n'));
+
+    private final static BbanStructure FINLAND_STRUCTURE = new BbanStructure(
+        BbanStructureEntry.bankCode(6, 'n'),
+        BbanStructureEntry.accountNumber(7, 'n'),
+        BbanStructureEntry.nationalCheckDigit(1, 'n'));
+
     static {
         structures = new EnumMap<CountryCode, BbanStructure>(CountryCode.class);
 
@@ -101,8 +111,6 @@ public class BbanStructure {
                         BbanStructureEntry.accountType(2, 'n'),
                         BbanStructureEntry.accountNumber(8, 'c')));
 
-        structures.put(CountryCode.BL, BbanStructure.FRENCH_STRUCTURE);
-
         structures.put(CountryCode.BY,
                 new BbanStructure(
                         BbanStructureEntry.bankCode(4, 'c'),
@@ -158,20 +166,29 @@ public class BbanStructure {
                         BbanStructureEntry.accountNumber(9, 'n'),
                         BbanStructureEntry.nationalCheckDigit(1, 'n')));
 
-        structures.put(CountryCode.FI,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(6, 'n'),
-                        BbanStructureEntry.accountNumber(7, 'n'),
-                        BbanStructureEntry.nationalCheckDigit(1, 'n')));
+        // Finland and its sub-territory (see https://www.iban.com/structure)
+        structures.put(CountryCode.FI, BbanStructure.FINLAND_STRUCTURE);
+        structures.put(CountryCode.AX, BbanStructure.FINLAND_STRUCTURE);
 
+        // France and its sub-territories (see https://www.iban.com/structure)
         structures.put(CountryCode.FR, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.GF, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.GP, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.MQ, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.RE, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.PF, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.TF, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.YT, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.NC, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.BL, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.MF, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.PM, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.WF, BbanStructure.FRENCH_STRUCTURE);
 
         structures.put(CountryCode.GE,
                 new BbanStructure(
                         BbanStructureEntry.bankCode(2, 'a'),
                         BbanStructureEntry.accountNumber(16, 'n')));
-
-        structures.put(CountryCode.GF, BbanStructure.FRENCH_STRUCTURE);
 
         structures.put(CountryCode.GI,
                 new BbanStructure(
@@ -182,8 +199,6 @@ public class BbanStructure {
                 new BbanStructure(
                         BbanStructureEntry.bankCode(4, 'n'),
                         BbanStructureEntry.accountNumber(10, 'n')));
-
-        structures.put(CountryCode.GP, BbanStructure.FRENCH_STRUCTURE);
 
         structures.put(CountryCode.GR,
                 new BbanStructure(
@@ -280,8 +295,6 @@ public class BbanStructure {
                         BbanStructureEntry.bankCode(3, 'n'),
                         BbanStructureEntry.accountNumber(13, 'c')));
 
-        structures.put(CountryCode.MF, BbanStructure.FRENCH_STRUCTURE);
-
         structures.put(CountryCode.MK,
                 new BbanStructure(
                         BbanStructureEntry.bankCode(3, 'n'),
@@ -312,17 +325,18 @@ public class BbanStructure {
                         BbanStructureEntry.bankCode(2, 'c'),
                         BbanStructureEntry.accountNumber(18, 'c')));
 
-        structures.put(CountryCode.MC, BbanStructure.FRENCH_STRUCTURE);
+        structures.put(CountryCode.MC,
+                new BbanStructure(
+                        BbanStructureEntry.bankCode(5, 'n'),
+                        BbanStructureEntry.branchCode(5, 'n'),
+                        BbanStructureEntry.accountNumber(11, 'c'),
+                        BbanStructureEntry.nationalCheckDigit(2, 'n')));
 
         structures.put(CountryCode.ME,
                 new BbanStructure(
                         BbanStructureEntry.bankCode(3, 'n'),
                         BbanStructureEntry.accountNumber(13, 'n'),
                         BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.MQ, BbanStructure.FRENCH_STRUCTURE);
-
-        structures.put(CountryCode.NC, BbanStructure.FRENCH_STRUCTURE);
 
         structures.put(CountryCode.NL,
                 new BbanStructure(
@@ -335,14 +349,10 @@ public class BbanStructure {
                         BbanStructureEntry.accountNumber(6, 'n'),
                         BbanStructureEntry.nationalCheckDigit(1, 'n')));
 
-        structures.put(CountryCode.PF, BbanStructure.FRENCH_STRUCTURE);
-
         structures.put(CountryCode.PK,
                 new BbanStructure(
                         BbanStructureEntry.bankCode(4, 'c'),
                         BbanStructureEntry.accountNumber(16, 'n')));
-
-        structures.put(CountryCode.PM, BbanStructure.FRENCH_STRUCTURE);
 
         structures.put(CountryCode.PS,
                 new BbanStructure(
@@ -362,8 +372,6 @@ public class BbanStructure {
                         BbanStructureEntry.branchCode(4, 'n'),
                         BbanStructureEntry.accountNumber(11, 'n'),
                         BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.RE, BbanStructure.FRENCH_STRUCTURE);
 
         structures.put(CountryCode.RO,
                 new BbanStructure(
@@ -440,8 +448,6 @@ public class BbanStructure {
                         BbanStructureEntry.bankCode(5, 'n'),
                         BbanStructureEntry.accountNumber(12, 'c')));
 
-        structures.put(CountryCode.TF, BbanStructure.FRENCH_STRUCTURE);
-
         structures.put(CountryCode.TN,
                 new BbanStructure(
                         BbanStructureEntry.bankCode(2, 'n'),
@@ -459,11 +465,12 @@ public class BbanStructure {
                         BbanStructureEntry.bankCode(6, 'n'),
                         BbanStructureEntry.accountNumber(19, 'n')));
 
-        structures.put(CountryCode.GB,
-                new BbanStructure(
-                        BbanStructureEntry.bankCode(4, 'a'),
-                        BbanStructureEntry.branchCode(6, 'n'),
-                        BbanStructureEntry.accountNumber(8, 'n')));
+
+        // UK and its sub-territories (see https://www.iban.com/structure)
+        structures.put(CountryCode.GB, BbanStructure.UNITED_KINGDOM_STRUCTURE);
+        structures.put(CountryCode.IM, BbanStructure.UNITED_KINGDOM_STRUCTURE);
+        structures.put(CountryCode.GG, BbanStructure.UNITED_KINGDOM_STRUCTURE);
+        structures.put(CountryCode.JE, BbanStructure.UNITED_KINGDOM_STRUCTURE);
 
         structures.put(CountryCode.AE,
                 new BbanStructure(
@@ -486,16 +493,12 @@ public class BbanStructure {
                         BbanStructureEntry.accountNumber(14, 'n'),
                         BbanStructureEntry.nationalCheckDigit(2, 'n')));
 
-        structures.put(CountryCode.WF, BbanStructure.FRENCH_STRUCTURE);
-
         structures.put(CountryCode.XK,
                 new BbanStructure(
                         BbanStructureEntry.bankCode(2, 'n'),
                         BbanStructureEntry.branchCode(2, 'n'),
                         BbanStructureEntry.accountNumber(10, 'n'),
                         BbanStructureEntry.nationalCheckDigit(2, 'n')));
-
-        structures.put(CountryCode.YT, BbanStructure.FRENCH_STRUCTURE);
 
         structures.put(CountryCode.IQ,
                 new BbanStructure(

--- a/src/test/java/org/iban4j/TestDataHelper.java
+++ b/src/test/java/org/iban4j/TestDataHelper.java
@@ -139,6 +139,12 @@ final class TestDataHelper {
                         .nationalCheckDigit("5")
                         .build(), "FI2112345600000785"},
                 {new Iban.Builder()
+                        .countryCode(CountryCode.AX)
+                        .bankCode("987654")
+                        .accountNumber("0002033")
+                        .nationalCheckDigit("5")
+                        .build(), "AX7898765400020335"},
+                {new Iban.Builder()
                         .countryCode(CountryCode.FR)
                         .bankCode("20041")
                         .branchCode("01005")
@@ -490,6 +496,24 @@ final class TestDataHelper {
                         .branchCode("601613")
                         .accountNumber("31926819")
                         .build(), "GB29NWBK60161331926819"},
+                {new Iban.Builder()
+                        .countryCode(CountryCode.IM)
+                        .bankCode("HBUK")
+                        .branchCode("401276")
+                        .accountNumber("12345678")
+                        .build(), "IM20HBUK40127612345678"},
+                {new Iban.Builder()
+                        .countryCode(CountryCode.GG)
+                        .bankCode("INGB")
+                        .branchCode("238859")
+                        .accountNumber("12345678")
+                        .build(), "GG65INGB23885912345678"},
+                {new Iban.Builder()
+                        .countryCode(CountryCode.JE)
+                        .bankCode("DEUT")
+                        .branchCode("405081")
+                        .accountNumber("12345678")
+                        .build(), "JE51DEUT40508112345678"},
                 {new Iban.Builder()
                         .countryCode(CountryCode.VA)
                         .bankCode("001")


### PR DESCRIPTION
Hello

I'd like to propose a few changes to better match what I understood from https://www.iban.com/structure:
- Adding support for sub-territories of the United Kingdom and Finland
- Grouping together the declarations of the sub-territories to make it easier to check.
- Removing France structure re-use for Monaco for clarity as is not defined as a re-use of France (even if it has effectively the same structure)