### PR TITLE
Persist method argument names in bytecode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,9 @@
                 <version>3.10.1</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Spring Boot Ahead of Time Optimizations asked library to be compile with -parameters