### PR TITLE
support automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,18 @@
                 </configuration>
             </plugin>
 
+            <!-- generate a jar with the module name -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.iban4j</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
 
             <!-- SureFire testing -->
             <plugin>


### PR DESCRIPTION
Add `maven-jar-plugin` configuration in pom.xml to create an automatic module name.

It implements the issues #148 and #53. 

You can call 'mvn package', open the generated jar file `iban4j-3.2.10-RELEASE.jar` with a zip utility.
Open the file `META-INF/MANIFEST.MF` and you will find the entry `Automatic-Module-Name: org.iban4j`.

Sincerely

Marcel