### PR TITLE
Add public method validateBbanEntry to BbanStructure for BBAN entry validation by country

### DIFF
--- a/src/main/java/org/iban4j/IbanFormatException.java
+++ b/src/main/java/org/iban4j/IbanFormatException.java
@@ -178,6 +178,7 @@ public class IbanFormatException extends Iban4jException {
         COUNTRY_CODE_NOT_NULL,
 
         BBAN_LENGTH,
+        BBAN_INVALID_ENTRY_TYPE,
         BBAN_ONLY_DIGITS,
         BBAN_ONLY_UPPER_CASE_LETTERS,
         BBAN_ONLY_DIGITS_OR_LETTERS,

--- a/src/main/java/org/iban4j/IbanUtil.java
+++ b/src/main/java/org/iban4j/IbanUtil.java
@@ -34,10 +34,6 @@ public final class IbanUtil {
     private static final int CHECK_DIGIT_LENGTH = 2;
     private static final int BBAN_INDEX = CHECK_DIGIT_INDEX + CHECK_DIGIT_LENGTH;
 
-    private static final String ASSERT_UPPER_LETTERS = "[%s] must contain only upper case letters.";
-    private static final String ASSERT_DIGITS_AND_LETTERS = "[%s] must contain only digits or letters.";
-    private static final String ASSERT_DIGITS = "[%s] must contain only digits.";
-
     private IbanUtil() {
     }
 
@@ -398,49 +394,17 @@ public final class IbanUtil {
     private static void validateBbanEntries(final String iban,
                                             final BbanStructure structure) {
         final String bban = getBban(iban);
+        final CountryCode countryCode = CountryCode.getByCode(getCountryCode(iban));
         int bbanEntryOffset = 0;
-        for(final BbanStructureEntry entry : structure.getEntries()) {
+
+        for (final BbanStructureEntry entry : structure.getEntries()) {
             final int entryLength = entry.getLength();
             final String entryValue = bban.substring(bbanEntryOffset,
                     bbanEntryOffset + entryLength);
 
-            bbanEntryOffset = bbanEntryOffset + entryLength;
+            bbanEntryOffset += entryLength;
 
-            // validate character type
-            validateBbanEntryCharacterType(entry, entryValue);
-        }
-    }
-
-    private static void validateBbanEntryCharacterType(final BbanStructureEntry entry,
-                                                       final String entryValue) {
-        switch (entry.getCharacterType()) {
-            case a:
-                for(char ch: entryValue.toCharArray()) {
-                    if(!Character.isUpperCase(ch)) {
-                        throw new IbanFormatException(BBAN_ONLY_UPPER_CASE_LETTERS,
-                                entry.getEntryType(), entryValue, ch,
-                                String.format(ASSERT_UPPER_LETTERS, entryValue));
-                    }
-                }
-                break;
-            case c:
-                for(char ch: entryValue.toCharArray()) {
-                    if(!Character.isLetterOrDigit(ch)) {
-                        throw new IbanFormatException(BBAN_ONLY_DIGITS_OR_LETTERS,
-                                entry.getEntryType(), entryValue, ch,
-                                String.format(ASSERT_DIGITS_AND_LETTERS, entryValue));
-                    }
-                }
-                break;
-            case n:
-                for(char ch: entryValue.toCharArray()) {
-                    if(!Character.isDigit(ch)) {
-                        throw new IbanFormatException(BBAN_ONLY_DIGITS,
-                                entry.getEntryType(), entryValue, ch,
-                                String.format(ASSERT_DIGITS, entryValue));
-                    }
-                }
-                break;
+            BbanStructure.validateBbanEntry(countryCode, entry.getEntryType(), entryValue);
         }
     }
 

--- a/src/main/java/org/iban4j/bban/BbanStructure.java
+++ b/src/main/java/org/iban4j/bban/BbanStructure.java
@@ -22,9 +22,18 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Optional;
 import org.iban4j.CountryCode;
+import org.iban4j.IbanFormatException;
+import org.iban4j.UnsupportedCountryException;
+
+import static org.iban4j.IbanFormatException.IbanFormatViolation.*;
 
 /** Class that represents BBAN structure */
 public class BbanStructure {
+
+  private static final String INVALID_ENTRY_TYPE = "Entry type [%s] does not exist for country [%s]";
+  private static final String ASSERT_UPPER_LETTERS = "[%s] must contain only upper case letters.";
+  private static final String ASSERT_DIGITS_AND_LETTERS = "[%s] must contain only digits or letters.";
+  private static final String ASSERT_DIGITS = "[%s] must contain only digits.";
 
   private static final EnumMap<CountryCode, BbanStructure> structures;
 
@@ -656,5 +665,91 @@ public class BbanStructure {
     }
 
     return length;
+  }
+
+  /**
+   * Validates a specific BBAN entry based on the country code, entry type, and value.
+   *
+   * @param countryCode the country code for which the validation should be performed.
+   * @param entryType the type of the BBAN entry (e.g., bank code, branch code).
+   * @param entryValue the value of the BBAN entry to validate.
+   * @throws UnsupportedCountryException if country is not supported.
+   * @throws IbanFormatException if the entry type does not exist for the given country or if the entry value is invalid.
+   */
+  public static void validateBbanEntry(final CountryCode countryCode,
+                                       final BbanEntryType entryType,
+                                       final String entryValue) {
+    final BbanStructure bbanStructure = forCountry(countryCode);
+
+    if (bbanStructure == null) {
+      throw new UnsupportedCountryException(countryCode.toString(),
+              String.format("Country code [%s] is not supported.", countryCode));
+    }
+
+    final BbanStructureEntry entry = bbanStructure.getEntries().stream()
+            .filter(e -> e.getEntryType().equals(entryType))
+            .findFirst()
+            .orElseThrow(() -> new IbanFormatException(BBAN_INVALID_ENTRY_TYPE,
+                    String.format(INVALID_ENTRY_TYPE,
+                            entryType.name(), countryCode)));
+
+    validateBbanEntryLength(entry, entryValue);
+    validateBbanEntryCharacterType(entry, entryValue);
+  }
+
+  /**
+   * Validates the length of a BBAN entry value.
+   *
+   * @param entry the BBAN structure entry defining the expected length.
+   * @param entryValue the value of the BBAN entry to validate.
+   * @throws IbanFormatException if the entry value length is incorrect.
+   */
+  private static void validateBbanEntryLength(final BbanStructureEntry entry,
+                                              final String entryValue) {
+    if (entryValue.length() != entry.getLength()) {
+      throw new IbanFormatException(BBAN_LENGTH,
+              String.format("Entry value [%s] must be exactly %d characters long.",
+                      entryValue, entry.getLength()));
+    }
+  }
+
+  /**
+   * Validates the character type of BBAN entry value.
+   *
+   * @param entry the BBAN structure entry defining the expected character type.
+   * @param entryValue the value of the BBAN entry to validate.
+   * @throws IbanFormatException if the entry value contains invalid characters.
+   */
+  private static void validateBbanEntryCharacterType(final BbanStructureEntry entry,
+                                                     final String entryValue) {
+    switch (entry.getCharacterType()) {
+      case a:
+        for(char ch: entryValue.toCharArray()) {
+          if(!Character.isUpperCase(ch)) {
+            throw new IbanFormatException(BBAN_ONLY_UPPER_CASE_LETTERS,
+                    entry.getEntryType(), entryValue, ch,
+                    String.format(ASSERT_UPPER_LETTERS, entryValue));
+          }
+        }
+        break;
+      case c:
+        for(char ch: entryValue.toCharArray()) {
+          if(!Character.isLetterOrDigit(ch)) {
+            throw new IbanFormatException(BBAN_ONLY_DIGITS_OR_LETTERS,
+                    entry.getEntryType(), entryValue, ch,
+                    String.format(ASSERT_DIGITS_AND_LETTERS, entryValue));
+          }
+        }
+        break;
+      case n:
+        for(char ch: entryValue.toCharArray()) {
+          if(!Character.isDigit(ch)) {
+            throw new IbanFormatException(BBAN_ONLY_DIGITS,
+                    entry.getEntryType(), entryValue, ch,
+                    String.format(ASSERT_DIGITS, entryValue));
+          }
+        }
+        break;
+    }
   }
 }

--- a/src/main/java/org/iban4j/bban/BbanStructure.java
+++ b/src/main/java/org/iban4j/bban/BbanStructure.java
@@ -724,8 +724,8 @@ public class BbanStructure {
                                                      final String entryValue) {
     switch (entry.getCharacterType()) {
       case a:
-        for(char ch: entryValue.toCharArray()) {
-          if(!Character.isUpperCase(ch)) {
+        for (char ch: entryValue.toCharArray()) {
+          if (!Character.isUpperCase(ch)) {
             throw new IbanFormatException(BBAN_ONLY_UPPER_CASE_LETTERS,
                     entry.getEntryType(), entryValue, ch,
                     String.format(ASSERT_UPPER_LETTERS, entryValue));
@@ -733,8 +733,8 @@ public class BbanStructure {
         }
         break;
       case c:
-        for(char ch: entryValue.toCharArray()) {
-          if(!Character.isLetterOrDigit(ch)) {
+        for (char ch: entryValue.toCharArray()) {
+          if (!Character.isLetterOrDigit(ch)) {
             throw new IbanFormatException(BBAN_ONLY_DIGITS_OR_LETTERS,
                     entry.getEntryType(), entryValue, ch,
                     String.format(ASSERT_DIGITS_AND_LETTERS, entryValue));
@@ -742,8 +742,8 @@ public class BbanStructure {
         }
         break;
       case n:
-        for(char ch: entryValue.toCharArray()) {
-          if(!Character.isDigit(ch)) {
+        for (char ch: entryValue.toCharArray()) {
+          if (!Character.isDigit(ch)) {
             throw new IbanFormatException(BBAN_ONLY_DIGITS,
                     entry.getEntryType(), entryValue, ch,
                     String.format(ASSERT_DIGITS, entryValue));

--- a/src/test/java/org/iban4j/bban/BbanStructureTest.java
+++ b/src/test/java/org/iban4j/bban/BbanStructureTest.java
@@ -1,0 +1,311 @@
+package org.iban4j.bban;
+
+import org.iban4j.CountryCode;
+import org.iban4j.IbanFormatException;
+import org.iban4j.UnsupportedCountryException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("BbanStructureTest")
+public class BbanStructureTest {
+
+    @Test
+    @DisplayName("Validates correct bank code for supported country")
+    public void validateCorrectBankCode() {
+        assertDoesNotThrow(() -> BbanStructure.validateBbanEntry(
+                CountryCode.FR,
+                BbanEntryType.bank_code,
+                "12345"
+        ));
+    }
+
+    @Test
+    @DisplayName("Throws exception for incorrect bank code")
+    public void validateIncorrectBankCode() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.FR,
+                        BbanEntryType.bank_code,
+                        "1234"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must be exactly 5 characters long."));
+    }
+
+    @Test
+    @DisplayName("Throws exception for bank code with invalid characters")
+    public void validateBankCodeWithInvalidCharacters() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.FR,
+                        BbanEntryType.bank_code,
+                        "12A45"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must contain only digits."));
+    }
+
+    @Test
+    @DisplayName("Validates correct branch code for supported country")
+    public void validateCorrectBranchCode() {
+        assertDoesNotThrow(() -> BbanStructure.validateBbanEntry(
+                CountryCode.FR,
+                BbanEntryType.branch_code,
+                "54321"
+        ));
+    }
+
+    @Test
+    @DisplayName("Throws exception for incorrect branch code")
+    public void validateIncorrectBranchCode() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.FR,
+                        BbanEntryType.branch_code,
+                        "5432"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must be exactly 5 characters long."));
+    }
+
+    @Test
+    @DisplayName("Throws exception for branch code with invalid characters")
+    public void validateBranchCodeWithInvalidCharacters() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.FR,
+                        BbanEntryType.branch_code,
+                        "5432B"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must contain only digits."));
+    }
+
+    @Test
+    @DisplayName("Validates correct account number for supported country")
+    public void validateCorrectAccountNumber() {
+        assertDoesNotThrow(() -> BbanStructure.validateBbanEntry(
+                CountryCode.FR,
+                BbanEntryType.account_number,
+                "ABCDEFGHIJK"
+        ));
+    }
+
+    @Test
+    @DisplayName("Throws exception for incorrect account number")
+    public void validateIncorrectAccountNumber() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.FR,
+                        BbanEntryType.account_number,
+                        "123456"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must be exactly 11 characters long."));
+    }
+
+    @Test
+    @DisplayName("Throws exception for account number with invalid characters")
+    public void validateAccountNumberWithInvalidCharacters() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.FR,
+                        BbanEntryType.account_number,
+                        "ABC@DEFGHIJ"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must contain only digits or letters."));
+    }
+
+    @Test
+    @DisplayName("Validates correct national check digit")
+    public void validateCorrectNationalCheckDigit() {
+        assertDoesNotThrow(() -> BbanStructure.validateBbanEntry(
+                CountryCode.FR,
+                BbanEntryType.national_check_digit,
+                "12"
+        ));
+    }
+
+    @Test
+    @DisplayName("Throws exception for incorrect national check digit")
+    public void validateIncorrectNationalCheckDigit() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.FR,
+                        BbanEntryType.national_check_digit,
+                        "1A"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must contain only digits."));
+    }
+
+    @Test
+    @DisplayName("Throws exception for national check digit with invalid characters")
+    public void validateNationalCheckDigitWithInvalidCharacters() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.FR,
+                        BbanEntryType.national_check_digit,
+                        "1C"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must contain only digits."));
+    }
+
+    @Test
+    @DisplayName("Validates correct account type")
+    public void validateCorrectAccountType() {
+        assertDoesNotThrow(() -> BbanStructure.validateBbanEntry(
+                CountryCode.BR,
+                BbanEntryType.account_type,
+                "A"
+        ));
+    }
+
+    @Test
+    @DisplayName("Throws exception for incorrect account type")
+    public void validateIncorrectAccountType() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.BR,
+                        BbanEntryType.account_type,
+                        "AA"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must be exactly 1 characters long."));
+    }
+
+    @Test
+    @DisplayName("Throws exception for account type with invalid characters")
+    public void validateAccountTypeWithInvalidCharacters() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.BR,
+                        BbanEntryType.account_type,
+                        "b"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must contain only upper case letters."));
+    }
+
+    @Test
+    @DisplayName("Validates correct owner account number")
+    public void validateCorrectOwnerAccountNumber() {
+        assertDoesNotThrow(() -> BbanStructure.validateBbanEntry(
+                CountryCode.BR,
+                BbanEntryType.owner_account_number,
+                "1"
+        ));
+    }
+
+    @Test
+    @DisplayName("Throws exception for incorrect owner account number")
+    public void validateIncorrectOwnerAccountNumber() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.BR,
+                        BbanEntryType.owner_account_number,
+                        "12"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must be exactly 1 characters long."));
+    }
+
+    @Test
+    @DisplayName("Throws exception for owner account number with invalid characters")
+    public void validateOwnerAccountNumberWithInvalidCharacters() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.BR,
+                        BbanEntryType.owner_account_number,
+                        "!"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must contain only digits or letters."));
+    }
+
+    @Test
+    @DisplayName("Validates correct identification number")
+    public void validateCorrectIdentificationNumber() {
+        assertDoesNotThrow(() -> BbanStructure.validateBbanEntry(
+                CountryCode.IS,
+                BbanEntryType.identification_number,
+                "1234567890"
+        ));
+    }
+
+    @Test
+    @DisplayName("Throws exception for incorrect identification number")
+    public void validateIncorrectIdentificationNumber() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.IS,
+                        BbanEntryType.identification_number,
+                        "ABCDEFGHIJ"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must contain only digits."));
+    }
+
+    @Test
+    @DisplayName("Throws exception for identification number with invalid characters")
+    public void validateIdentificationNumberWithInvalidCharacters() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.IS,
+                        BbanEntryType.identification_number,
+                        "12345ABCDE"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("must contain only digits."));
+    }
+
+    @Test
+    @DisplayName("Throws exception for unsupported country")
+    public void throwsExceptionForUnsupportedCountry() {
+        UnsupportedCountryException thrown = assertThrows(
+                UnsupportedCountryException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.AM,
+                        BbanEntryType.bank_code,
+                        "12345"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("Country code [AM] is not supported."));
+    }
+
+    @Test
+    @DisplayName("Throws exception for invalid entry type")
+    public void throwsExceptionForInvalidEntryType() {
+        IbanFormatException thrown = assertThrows(
+                IbanFormatException.class,
+                () -> BbanStructure.validateBbanEntry(
+                        CountryCode.FR,
+                        BbanEntryType.account_type,
+                        "A"
+                )
+        );
+        assertThat(thrown.getMessage(), containsString("Entry type [account_type] does not exist for country [FR]"));
+    }
+}
+


### PR DESCRIPTION
This PR addresses issue #155 and introduces a public API to validate specific parts of a BBAN based on the country. As described in the issue, a common use case might be validating an isolated bank code by checking its length and allowed characters, given the country.

I aimed to follow the project's coding style and implemented the public method and its logic in `BbanStructure`. While considering whether this should reside in `IbanUtil`, I concluded that a dedicated util class might not be necessary. `BbanStructure` already exposes public methods like `forCountry` and encapsulates the logic needed to validate entries for a specific country.

As part of this change, the `validateBbanEntryCharacterType` method was moved from `IbanUtil` to `BbanStructure`. `IbanUtil` now delegates BBAN entries validation to the newly created method in `BbanStructure`.

I kept exception handling consistent with the current codebase, continuing to use `IbanFormatException` as done in `IbanUtil`. However, there might be a discussion to have regarding whether it’s conceptually appropriate to throw an `IbanFormatException` when validating a single BBAN entry. I don’t have a strong opinion on this but wanted to point it out for consideration.