### PR TITLE
Fix: Estonia and Sweden format

### DIFF
--- a/src/main/java/org/iban4j/bban/BbanStructure.java
+++ b/src/main/java/org/iban4j/bban/BbanStructure.java
@@ -184,8 +184,7 @@ public class BbanStructure {
         CountryCode.EE,
         new BbanStructure(
             BbanStructureEntry.bankCode(2, 'n'),
-            BbanStructureEntry.branchCode(2, 'n'),
-            BbanStructureEntry.accountNumber(11, 'n'),
+            BbanStructureEntry.accountNumber(13, 'n'),
             BbanStructureEntry.nationalCheckDigit(1, 'n')));
 
     structures.put(
@@ -528,7 +527,9 @@ public class BbanStructure {
     structures.put(
         CountryCode.SE,
         new BbanStructure(
-            BbanStructureEntry.bankCode(3, 'n'), BbanStructureEntry.accountNumber(17, 'n')));
+            BbanStructureEntry.bankCode(3, 'n'),
+            BbanStructureEntry.accountNumber(16, 'n'),
+            BbanStructureEntry.nationalCheckDigit(1, 'n')));
 
     structures.put(
         CountryCode.CH,

--- a/src/test/java/org/iban4j/TestDataHelper.java
+++ b/src/test/java/org/iban4j/TestDataHelper.java
@@ -188,13 +188,12 @@ final class TestDataHelper {
             "DO28BAGR00000001212453611324"
           },
           {
-            new Iban.Builder()
-                .countryCode(CountryCode.EE)
-                .bankCode("22")
-                .branchCode("00")
-                .accountNumber("22102014568")
-                .nationalCheckDigit("5")
-                .build(),
+        new Iban.Builder()
+            .countryCode(CountryCode.EE)
+            .bankCode("22")
+            .accountNumber("0022102014568")
+            .nationalCheckDigit("5")
+            .build(),
             "EE382200221020145685"
           },
           {
@@ -723,11 +722,12 @@ final class TestDataHelper {
             "ES9121000418450200051332"
           },
           {
-            new Iban.Builder()
-                .countryCode(CountryCode.SE)
-                .bankCode("500")
-                .accountNumber("00000058398257466")
-                .build(),
+        new Iban.Builder()
+            .countryCode(CountryCode.SE)
+            .bankCode("500")
+            .accountNumber("0000005839825746")
+            .nationalCheckDigit("6")
+            .build(),
             "SE4550000000058398257466"
           },
           {


### PR DESCRIPTION
## Problem
The current BBAN (Basic Bank Account Number) structure definitions for Estonia (EE) and Sweden (SE) are incorrect, causing validation failures for legitimate IBANs from these countries.
## Changes Made
Estonia (EE):
- Before: 2-digit bank code + 2-digit branch code + 11-digit account number + 1-digit check digit
- After: 2-digit bank code + 13-digit account number + 1-digit check digit
- Rationale: Estonian IBANs don't use separate branch codes. The account number field is 13 digits, not 11.  

Sweden (SE):
- Before: 3-digit bank code + 17-digit account number
- After: 3-digit bank code + 16-digit account number + 1-digit national check digit
- Rationale: Swedish account numbers include a mandatory check digit as the last digit.
## References
Estonia: [Estonian Banking Association IBAN Calculator](https://pangaliit.ee/settlements-and-standards/bban-greater-than-iban-calculator)
Sweden: [Swedish Payments Council - Bank Account Number Structure Manual](https://www.bankgirot.se/globalassets/dokument/anvandarmanualer/bankernaskontonummeruppbyggnad_anvandarmanual_sv.pdf)