### PR TITLE
chore: avoid allocations in Iso7064 utils class during MOD 97 calculation

### DIFF
--- a/src/main/java/org/iban4j/countryrules/util/Iso7064.java
+++ b/src/main/java/org/iban4j/countryrules/util/Iso7064.java
@@ -1,14 +1,10 @@
 package org.iban4j.countryrules.util;
 
-import java.math.BigInteger;
-
 /**
  * Utilities for ISO 7064 MOD 97-10 calculations, implemented in a streaming manner
  * to avoid overflows for long numeric strings.
  */
 public final class Iso7064 {
-
-  private static final BigInteger NINETY_SEVEN = BigInteger.valueOf(97);
 
   private Iso7064() {
   }
@@ -17,19 +13,19 @@ public final class Iso7064 {
    * Compute the MOD 97-10 remainder for a numeric string. Returns -1 for invalid input.
    */
   public static int mod97_10(final String numeric) {
-    if (numeric == null || numeric.length() == 0) {
+    if (numeric == null || numeric.isEmpty()) {
       return -1;
     }
-    BigInteger remainder = BigInteger.ZERO;
+    int remainder = 0;
     for (int i = 0; i < numeric.length(); i++) {
       final char ch = numeric.charAt(i);
       if (ch < '0' || ch > '9') {
         return -1;
       }
-      remainder = remainder.multiply(BigInteger.TEN).add(BigInteger.valueOf(ch - '0'));
-      remainder = remainder.mod(NINETY_SEVEN);
+      remainder = remainder * 10 + (ch - '0');
+      remainder = remainder % 97;
     }
-    return remainder.intValue();
+    return remainder;
   }
 
   /**
@@ -37,19 +33,11 @@ public final class Iso7064 {
    * Returns the two-digit string or null on invalid input.
    */
   public static String ribCheckDigits(final String numeric) {
-    if (numeric == null || numeric.length() == 0) {
+    int remainder = mod97_10(numeric);
+    if (remainder < 0) {
       return null;
     }
-    for (int i = 0; i < numeric.length(); i++) {
-      final char ch = numeric.charAt(i);
-      if (ch < '0' || ch > '9') {
-        return null;
-      }
-    }
-    BigInteger number = new BigInteger(numeric);
-    number = number.multiply(BigInteger.valueOf(100));
-    BigInteger remainder = number.mod(NINETY_SEVEN);
-    long value = 97 - remainder.longValue();
+    int value = 97 - ((remainder * 100) % 97);
     return String.format("%02d", value);
   }
 }

--- a/src/test/java/org/iban4j/countryrules/util/Iso7064Test.java
+++ b/src/test/java/org/iban4j/countryrules/util/Iso7064Test.java
@@ -1,0 +1,33 @@
+package org.iban4j.countryrules.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class Iso7064Test {
+
+    @ParameterizedTest
+    @CsvSource({
+            "13,13",
+            "97,0",
+            "12345,26",
+            "1234a5678,-1",
+            "\"\",-1",
+            ",-1"
+    })
+    void mod97_10(String input, int mod97) {
+        Assertions.assertEquals(mod97, Iso7064.mod97_10(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1,94",
+            "123,19",
+            "123a4546,",
+            "\"\",",
+            ","
+    })
+    void ribCheckDigits(String input, String expectedDigits) {
+        Assertions.assertEquals(expectedDigits, Iso7064.ribCheckDigits(input));
+    }
+}


### PR DESCRIPTION
Iso7064 uses BigInteger to calculate the MOD 97 for input number in string representation, which causes allocations on every operation. But we can avoid using BigInteger and use primitive types instead because we don't need to store large numbers in memory. Using primitives should help with performance in case of frequent validations.

**Why don't we need large numbers in memory?**

Because we can use mathematics instead.

For example: 12345 % 97 = **26**
1 % 97 = 1 => 1 * 10 + 2
12 % 97 = 12
123 % 97 = 26
264 % 97 = 70
705 % 97 = **26**

Same for (123 * 100) % 97 = **78**
123 % 97 = 26
2600 % 97 = **78**

Related to #169 