### PR TITLE
fix: Move default rule initialization to nested class inside CountryRulesRegistry to ensure thread-safe lazy initialization

### DIFF
--- a/src/main/java/org/iban4j/IbanUtil.java
+++ b/src/main/java/org/iban4j/IbanUtil.java
@@ -20,6 +20,7 @@ import static org.iban4j.IbanFormatException.IbanFormatViolation.*;
 import org.iban4j.bban.BbanEntryType;
 import org.iban4j.bban.BbanStructure;
 import org.iban4j.bban.BbanStructureEntry;
+import org.iban4j.countryrules.CountrySpecificRules;
 
 /**
  * Iban Utility Class
@@ -113,7 +114,7 @@ public final class IbanUtil {
     try {
       validate(iban);
       final Iban ibanObj = Iban.valueOf(iban);
-      return org.iban4j.countryrules.CountrySpecificRules.isValid(ibanObj, config);
+      return CountrySpecificRules.isValid(ibanObj, config);
     } catch (Exception e) {
       return false;
     }

--- a/src/main/java/org/iban4j/IbanValidator.java
+++ b/src/main/java/org/iban4j/IbanValidator.java
@@ -15,9 +15,7 @@
  */
 package org.iban4j;
 
-import org.iban4j.countryrules.CountryRulesAlgorithm;
-import org.iban4j.countryrules.CountryRulesAlgorithms;
-import org.iban4j.countryrules.CountryRulesRegistry;
+import org.iban4j.countryrules.CountrySpecificRules;
 
 /**
  * Non-static, reusable IBAN validator with configurable validation options.
@@ -55,25 +53,11 @@ public final class IbanValidator {
      */
     public void validate(String iban) throws IbanFormatException, 
             InvalidCheckDigitException, UnsupportedCountryException {
-        // Perform base IBAN validation
-        IbanUtil.validate(iban);
-        
-        // Perform country-specific rules validation if enabled
-        if (config != null && config.isEnabled()) {
-            CountryRulesAlgorithms.ensureInitialized();
-            Iban ibanObj = Iban.valueOf(iban);
-            CountryRulesAlgorithm algorithm = CountryRulesRegistry.get(ibanObj.getCountryCode());
-            
-            if (algorithm != null && !algorithm.validate(ibanObj)) {
-                // Note: COUNTRY_RULES_FAILED is currently only applicable to national check digit validation
-                // since that's the only country-specific rule implemented at this time
-                throw new IbanFormatException(
-                    IbanFormatException.IbanFormatViolation.COUNTRY_RULES_FAILED,
-                    iban,
-                    "Country-specific rules validation failed for " + iban
-                );
-            }
-        }
+        // Perform base IBAN validation and get IBAN object
+        Iban ibanObj = Iban.valueOf(iban);
+
+        // Validate country specific rules if enabled by configuration
+        CountrySpecificRules.validate(ibanObj, config);
     }
     
     /**

--- a/src/main/java/org/iban4j/IbanValidator.java
+++ b/src/main/java/org/iban4j/IbanValidator.java
@@ -15,6 +15,7 @@
  */
 package org.iban4j;
 
+import org.iban4j.IbanFormatException.IbanFormatViolation;
 import org.iban4j.countryrules.CountrySpecificRules;
 
 /**
@@ -57,7 +58,13 @@ public final class IbanValidator {
         Iban ibanObj = Iban.valueOf(iban);
 
         // Validate country specific rules if enabled by configuration
-        CountrySpecificRules.validate(ibanObj, config);
+        if (!CountrySpecificRules.isValid(ibanObj, config)) {
+            throw new IbanFormatException(
+                    IbanFormatViolation.COUNTRY_RULES_FAILED,
+                    iban,
+                    "Country-specific rules validation failed for " + iban
+            );
+        }
     }
     
     /**

--- a/src/main/java/org/iban4j/countryrules/CountryRulesAlgorithms.java
+++ b/src/main/java/org/iban4j/countryrules/CountryRulesAlgorithms.java
@@ -1,28 +1,12 @@
 package org.iban4j.countryrules;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-import org.iban4j.countryrules.algorithms.*;
-
+/**
+ * @deprecated default rule initialization has been moved to {@link CountryRulesRegistry}
+ */
+@Deprecated(forRemoval = true)
 public final class CountryRulesAlgorithms {
-  private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
   private CountryRulesAlgorithms() {}
   public static void ensureInitialized() {
-    if (INITIALIZED.compareAndSet(false, true)) {
-      CountryRulesRegistry.register(new BeNationalCheckDigit());
-      CountryRulesRegistry.register(new EsNationalCheckDigit());
-      CountryRulesRegistry.register(new BaNationalCheckDigit());
-      CountryRulesRegistry.register(new FiNationalCheckDigit());
-      CountryRulesRegistry.register(new FrNationalCheckDigit());
-      CountryRulesRegistry.register(new ItNationalCheckDigit());
-      CountryRulesRegistry.register(new MkNationalCheckDigit());
-      CountryRulesRegistry.register(new MeNationalCheckDigit());
-      CountryRulesRegistry.register(new NlNationalCheckDigit());
-      CountryRulesRegistry.register(new NoNationalCheckDigit());
-      CountryRulesRegistry.register(new PtNationalCheckDigit());
-      CountryRulesRegistry.register(new RsNationalCheckDigit());
-      CountryRulesRegistry.register(new SkNationalCheckDigit());
-      CountryRulesRegistry.register(new SiNationalCheckDigit());
-      CountryRulesRegistry.register(new TnNationalCheckDigit());
-    }
+    // NO op
   }
 }

--- a/src/main/java/org/iban4j/countryrules/CountryRulesRegistry.java
+++ b/src/main/java/org/iban4j/countryrules/CountryRulesRegistry.java
@@ -1,19 +1,65 @@
 package org.iban4j.countryrules;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.iban4j.CountryCode;
+import org.iban4j.countryrules.algorithms.BaNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.BeNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.EsNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.FiNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.FrNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.ItNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.MeNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.MkNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.NlNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.NoNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.PtNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.RsNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.SiNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.SkNationalCheckDigit;
+import org.iban4j.countryrules.algorithms.TnNationalCheckDigit;
 
 public final class CountryRulesRegistry {
-  private static final Map<CountryCode, CountryRulesAlgorithm> COUNTRY_TO_ALGORITHM =
-      new ConcurrentHashMap<CountryCode, CountryRulesAlgorithm>();
+
   private CountryRulesRegistry() {}
-  public static void register(final CountryRulesAlgorithm algorithm) {
-    if (algorithm == null) return;
-    COUNTRY_TO_ALGORITHM.put(algorithm.getCountry(), algorithm);
+
+  public static void register(CountryRulesAlgorithm algorithm) {
+    if (algorithm == null) {
+        return;
+    }
+    Holder.COUNTRY_TO_ALGORITHM.put(algorithm.getCountry(), algorithm);
   }
-  public static CountryRulesAlgorithm get(final CountryCode countryCode) {
-    return COUNTRY_TO_ALGORITHM.get(countryCode);
+
+  public static CountryRulesAlgorithm get(CountryCode countryCode) {
+    return Holder.COUNTRY_TO_ALGORITHM.get(countryCode);
   }
-  public static void clear() { COUNTRY_TO_ALGORITHM.clear(); }
+
+  public static void clear() { Holder.COUNTRY_TO_ALGORITHM.clear(); }
+
+  /**
+   * Using private nested class with static field insures that algorithms are initialized in a thread-safe and lazy manner.
+   */
+  private static class Holder {
+    private static final Map<CountryCode, CountryRulesAlgorithm> COUNTRY_TO_ALGORITHM = new ConcurrentHashMap<>();
+    static {
+      List.of(
+              new BeNationalCheckDigit(),
+              new EsNationalCheckDigit(),
+              new BaNationalCheckDigit(),
+              new FiNationalCheckDigit(),
+              new FrNationalCheckDigit(),
+              new ItNationalCheckDigit(),
+              new MkNationalCheckDigit(),
+              new MeNationalCheckDigit(),
+              new NlNationalCheckDigit(),
+              new NoNationalCheckDigit(),
+              new PtNationalCheckDigit(),
+              new RsNationalCheckDigit(),
+              new SkNationalCheckDigit(),
+              new SiNationalCheckDigit(),
+              new TnNationalCheckDigit()
+      ).forEach(rule -> COUNTRY_TO_ALGORITHM.put(rule.getCountry(), rule));
+    }
+  }
 }

--- a/src/main/java/org/iban4j/countryrules/CountrySpecificRules.java
+++ b/src/main/java/org/iban4j/countryrules/CountrySpecificRules.java
@@ -31,11 +31,7 @@ public final class CountrySpecificRules {
    */
   public static void validate(final Iban iban, final ValidationConfig config) {
     if (!isValid(iban, config)) {
-      throw new IbanFormatException(
-              IbanFormatViolation.COUNTRY_RULES_FAILED,
-              iban,
-              "Country-specific rules validation failed for " + iban
-      );
+      throw new IllegalArgumentException("Country-specific rules check failed for " + iban);
     }
   }
 }

--- a/src/main/java/org/iban4j/countryrules/CountrySpecificRules.java
+++ b/src/main/java/org/iban4j/countryrules/CountrySpecificRules.java
@@ -1,6 +1,8 @@
 package org.iban4j.countryrules;
 
 import org.iban4j.Iban;
+import org.iban4j.IbanFormatException;
+import org.iban4j.IbanFormatException.IbanFormatViolation;
 import org.iban4j.ValidationConfig;
 
 public final class CountrySpecificRules {
@@ -8,17 +10,17 @@ public final class CountrySpecificRules {
 
   public static boolean isValid(final Iban iban, final ValidationConfig config) {
     if (config == null || !config.isEnabled()) return true;
-    CountryRulesAlgorithms.ensureInitialized();
     final CountryRulesAlgorithm algorithm = CountryRulesRegistry.get(iban.getCountryCode());
-    if (algorithm == null) {
-      return true;
-    }
-    return algorithm.validate(iban);
+    return algorithm == null || algorithm.validate(iban);
   }
 
   public static void validate(final Iban iban, final ValidationConfig config) {
     if (!isValid(iban, config)) {
-      throw new IllegalArgumentException("Country-specific rules check failed for " + iban); 
+      throw new IbanFormatException(
+              IbanFormatViolation.COUNTRY_RULES_FAILED,
+              iban,
+              "Country-specific rules validation failed for " + iban
+      );
     }
   }
 }

--- a/src/test/java/org/iban4j/countryrules/CountryRulesRegistryTest.java
+++ b/src/test/java/org/iban4j/countryrules/CountryRulesRegistryTest.java
@@ -11,15 +11,12 @@ public class CountryRulesRegistryTest {
 
     @Test
     public void ensureInitializedRegistersBuiltins() {
-        CountryRulesAlgorithms.ensureInitialized();
         assertNotNull(CountryRulesRegistry.get(CountryCode.BE));
         assertNotNull(CountryRulesRegistry.get(CountryCode.ES));
     }
 
     @Test
     public void registerOverridesExistingAndCanBeRestored() {
-        CountryRulesAlgorithms.ensureInitialized();
-
         final CountryRulesAlgorithm original = CountryRulesRegistry.get(CountryCode.BE);
         final CountryRulesAlgorithm custom = new CountryRulesAlgorithm() {
             @Override

--- a/src/test/java/org/iban4j/countryrules/NationalCheckDigitRegistryTest.java
+++ b/src/test/java/org/iban4j/countryrules/NationalCheckDigitRegistryTest.java
@@ -11,15 +11,12 @@ public class NationalCheckDigitRegistryTest {
 
     @Test
     public void ensureInitializedRegistersBuiltins() {
-        CountryRulesAlgorithms.ensureInitialized();
         assertNotNull(CountryRulesRegistry.get(CountryCode.BE));
         assertNotNull(CountryRulesRegistry.get(CountryCode.ES));
     }
 
     @Test
     public void registerOverridesExistingAndCanBeRestored() {
-        CountryRulesAlgorithms.ensureInitialized();
-
         final CountryRulesAlgorithm original = CountryRulesRegistry.get(CountryCode.BE);
         final CountryRulesAlgorithm custom = new CountryRulesAlgorithm() {
             @Override


### PR DESCRIPTION
There was an issue with the multithreaded execution of country rules validations - if one thread starts rules initialisation, the second thread does not wait for it to be finished and executes the validation without registered country rules:

| Thread 1 |Thread 2 |
|--------|--------|
| CountryRulesAlgorithms.ensureInitialized() |  |
| INITIALIZED.compareAndSet(false, true) == true | |
| | CountryRulesAlgorithms.ensureInitialized() |
| | INITIALIZED.compareAndSet(false, true) == false|
| | return from ensureInitialized | 
| | CountryRulesRegistry.get |
| CountryRulesRegistry.register | |

To ensure that never happens, but rules are still loaded only when they are needed, the default rule initialisation was moved to CountryRulesRegistry - whenever we try to access the rules registry, default rules are loaded automatically in a thread-safe manner (Java guarantees that)