### PR TITLE
chore: Add javadoc where needed to get rid of warnings

### DIFF
--- a/src/main/java/org/iban4j/CharacterUtil.java
+++ b/src/main/java/org/iban4j/CharacterUtil.java
@@ -33,6 +33,8 @@ public final class CharacterUtil {
     /**
      * Checks if character is ASCII digit (0-9 only).
      * Rejects Unicode digits like Arabic-Indic digits (٠-٩) or other Unicode digit characters.
+     * @param ch character to check
+     * @return {@code true} if {@code ch} is an ASCII digit, otherwise {@code false}
      */
     public static boolean isAsciiDigit(char ch) {
         return ch >= '0' && ch <= '9';
@@ -41,6 +43,8 @@ public final class CharacterUtil {
     /**
      * Checks if character is ASCII uppercase letter (A-Z only).
      * Rejects Unicode letters like Cyrillic (А, Е) or other Unicode letter characters.
+     * @param ch character to check
+     * @return {@code true} if {@code ch} is an ASCII uppercase latter, otherwise {@code false}
      */
     public static boolean isAsciiUppercaseLetter(char ch) {
         return ch >= 'A' && ch <= 'Z';
@@ -49,6 +53,8 @@ public final class CharacterUtil {
     /**
      * Checks if character is valid for financial code alphanumeric fields (A-Z, 0-9).
      * Used for IBAN and BIC validation where only ASCII alphanumeric characters are allowed.
+     * @param ch character to check
+     * @return {@code true} if {@code ch} is an ASCII uppercase latter or an ASCII digit, otherwise {@code false}
      */
     public static boolean isValidAlphanumeric(char ch) {
         return isAsciiUppercaseLetter(ch) || isAsciiDigit(ch);

--- a/src/main/java/org/iban4j/IbanValidator.java
+++ b/src/main/java/org/iban4j/IbanValidator.java
@@ -96,6 +96,8 @@ public final class IbanValidator {
      */
     public static final class Builder {
         private ValidationConfig config = ValidationConfig.builder().build();
+
+        private Builder(){}
         
         /**
          * Sets the validation config for the validator.

--- a/src/main/java/org/iban4j/ValidationConfig.java
+++ b/src/main/java/org/iban4j/ValidationConfig.java
@@ -65,6 +65,8 @@ public class ValidationConfig {
      */
     public static class Builder {
         private boolean enableNationalCheckDigitValidation = false;
+
+        private Builder() {}
         
         /**
          * Enables or disables national check digit validation.
@@ -77,10 +79,14 @@ public class ValidationConfig {
             return this;
         }
 
-        // Alias to avoid API churn during rename
+        /**
+         * Enables or disables country specific rules
+         * @see Builder#enableNationalCheckDigitValidation
+         * @param enabled true to enable validation
+         * @return this builder
+         */
         public Builder enableCountryRules(boolean enabled) {
-            this.enableNationalCheckDigitValidation = enabled;
-            return this;
+            return enableNationalCheckDigitValidation(enabled);
         }
         
         /**

--- a/src/main/java/org/iban4j/countryrules/CountryRulesAlgorithm.java
+++ b/src/main/java/org/iban4j/countryrules/CountryRulesAlgorithm.java
@@ -7,6 +7,16 @@ import org.iban4j.Iban;
  * SPI for country-specific rules validation (formerly national check digits).
  */
 public interface CountryRulesAlgorithm {
+  /**
+   * Country to which the algorithm should be applied to
+   * @return {@link CountryCode} for which country the rules can be applied
+   */
   CountryCode getCountry();
+
+  /**
+   * Validates {@link Iban} against rules specific for the country returned by {@link CountryRulesAlgorithm#getCountry()}
+   * @param iban IBAN to validate
+   * @return {@code true} if IBAN passes validations against country-specific rules
+   */
   boolean validate(Iban iban);
 }

--- a/src/main/java/org/iban4j/countryrules/CountryRulesAlgorithms.java
+++ b/src/main/java/org/iban4j/countryrules/CountryRulesAlgorithms.java
@@ -3,9 +3,16 @@ package org.iban4j.countryrules;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.iban4j.countryrules.algorithms.*;
 
+/**
+ * Helper class to register default country specific rules
+ */
 public final class CountryRulesAlgorithms {
   private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
   private CountryRulesAlgorithms() {}
+
+  /**
+   * Ensures that default country specific rules are registered in {@link CountryRulesRegistry}
+   */
   public static void ensureInitialized() {
     if (INITIALIZED.compareAndSet(false, true)) {
       CountryRulesRegistry.register(new BeNationalCheckDigit());

--- a/src/main/java/org/iban4j/countryrules/CountryRulesRegistry.java
+++ b/src/main/java/org/iban4j/countryrules/CountryRulesRegistry.java
@@ -4,16 +4,35 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.iban4j.CountryCode;
 
+/**
+ * Registry of country specific algorithms for {@link org.iban4j.Iban} validation
+ */
 public final class CountryRulesRegistry {
   private static final Map<CountryCode, CountryRulesAlgorithm> COUNTRY_TO_ALGORITHM =
       new ConcurrentHashMap<CountryCode, CountryRulesAlgorithm>();
   private CountryRulesRegistry() {}
+
+  /**
+   * Register algorithm with country specific IBAN validations.
+   * Overrides existing algorithm for that country if any exist
+   * @param algorithm algorithm implementation to register.
+   */
   public static void register(final CountryRulesAlgorithm algorithm) {
     if (algorithm == null) return;
     COUNTRY_TO_ALGORITHM.put(algorithm.getCountry(), algorithm);
   }
+
+  /**
+   * Retrieve algorithm with country specific IBAN validations for a given country
+   * @param countryCode which country's algorithm to use
+   * @return algorithm for given country or {@code null} if none is registered
+   */
   public static CountryRulesAlgorithm get(final CountryCode countryCode) {
     return COUNTRY_TO_ALGORITHM.get(countryCode);
   }
+
+  /**
+   * Clears all registered algorithms
+   */
   public static void clear() { COUNTRY_TO_ALGORITHM.clear(); }
 }

--- a/src/main/java/org/iban4j/countryrules/CountrySpecificRules.java
+++ b/src/main/java/org/iban4j/countryrules/CountrySpecificRules.java
@@ -3,9 +3,18 @@ package org.iban4j.countryrules;
 import org.iban4j.Iban;
 import org.iban4j.ValidationConfig;
 
+/**
+ * Class with static methods to validate {@link Iban} against country specific rules.
+ */
 public final class CountrySpecificRules {
   private CountrySpecificRules() {}
 
+  /**
+   * Validates the {@link Iban} against country specific rules if enabled.
+   * @param iban IBAN to validate
+   * @param config validation configuration
+   * @return {@code true} if IBAN passes country specific validation or if they are disabled
+   */
   public static boolean isValid(final Iban iban, final ValidationConfig config) {
     if (config == null || !config.isEnabled()) return true;
     CountryRulesAlgorithms.ensureInitialized();
@@ -16,6 +25,12 @@ public final class CountrySpecificRules {
     return algorithm.validate(iban);
   }
 
+  /**
+   * Validates {@link Iban} against country specific rules and throws exception when it is not valid.
+   * @see CountrySpecificRules#isValid
+   * @param iban IBAN to validate
+   * @param config validation configuration
+   */
   public static void validate(final Iban iban, final ValidationConfig config) {
     if (!isValid(iban, config)) {
       throw new IllegalArgumentException("Country-specific rules check failed for " + iban); 

--- a/src/main/java/org/iban4j/countryrules/algorithms/BaNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/BaNationalCheckDigit.java
@@ -7,6 +7,11 @@ import org.iban4j.countryrules.util.Iso7064;
 
 /** Bosnia and Herzegovina: ISO 7064 MOD 97-10 over entire BBAN. */
 public final class BaNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Bosnia and Herzegovina national check digit validator
+   */
+  public BaNationalCheckDigit() {
+  }
 
   @Override
   public CountryCode getCountry() {

--- a/src/main/java/org/iban4j/countryrules/algorithms/BeNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/BeNationalCheckDigit.java
@@ -6,6 +6,11 @@ import org.iban4j.countryrules.CountryRulesAlgorithm;
 
 /** Belgium: modulus 97 check on bankCode+accountNumber, 00 => 97 rule. */
 public final class BeNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Belgium national check digit validator
+   */
+  public BeNationalCheckDigit() {
+  }
 
   @Override
   public CountryCode getCountry() {

--- a/src/main/java/org/iban4j/countryrules/algorithms/EsNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/EsNationalCheckDigit.java
@@ -9,6 +9,12 @@ public final class EsNationalCheckDigit implements CountryRulesAlgorithm {
 
   private static final int[] WEIGHTS = {1, 2, 4, 8, 5, 10, 9, 7, 3, 6};
 
+  /**
+   * Created instance of Spain national check digit validator
+   */
+  public EsNationalCheckDigit() {
+  }
+
   @Override
   public CountryCode getCountry() {
     return CountryCode.ES;

--- a/src/main/java/org/iban4j/countryrules/algorithms/FiNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/FiNationalCheckDigit.java
@@ -6,6 +6,11 @@ import org.iban4j.countryrules.CountryRulesAlgorithm;
 
 /** Finland: Mod 10 with weights 2,1,2,1 from right to left over bank+account. */
 public final class FiNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Finland national check digit validator
+   */
+  public FiNationalCheckDigit() {
+  }
 
   @Override
   public CountryCode getCountry() {

--- a/src/main/java/org/iban4j/countryrules/algorithms/FrNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/FrNationalCheckDigit.java
@@ -7,6 +7,11 @@ import org.iban4j.countryrules.util.Iso7064;
 
 /** France: Mod 97 RIB with letter conversion. */
 public final class FrNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of France national check digit validator
+   */
+  public FrNationalCheckDigit() {
+  }
 
   @Override
   public CountryCode getCountry() {

--- a/src/main/java/org/iban4j/countryrules/algorithms/ItNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/ItNationalCheckDigit.java
@@ -6,6 +6,11 @@ import org.iban4j.countryrules.CountryRulesAlgorithm;
 
 /** Italy: odd/even positional value mapping over bank+branch+account produces a letter. */
 public final class ItNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Italy national check digit validator
+   */
+  public ItNationalCheckDigit() {
+  }
 
   @Override
   public CountryCode getCountry() {

--- a/src/main/java/org/iban4j/countryrules/algorithms/MeNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/MeNationalCheckDigit.java
@@ -7,6 +7,12 @@ import org.iban4j.countryrules.CountryRulesAlgorithm;
 
 /** Montenegro: ISO 7064 MOD 97-10 over BBAN. */
 public final class MeNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Montenegro national check digit validator
+   */
+  public MeNationalCheckDigit() {
+  }
+
   @Override
   public CountryCode getCountry() { return CountryCode.ME; }
   @Override

--- a/src/main/java/org/iban4j/countryrules/algorithms/MkNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/MkNationalCheckDigit.java
@@ -7,6 +7,12 @@ import org.iban4j.countryrules.CountryRulesAlgorithm;
 
 /** Macedonia: ISO 7064 MOD 97-10 over BBAN. */
 public final class MkNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Macedonia national check digit validator
+   */
+  public MkNationalCheckDigit() {
+  }
+
   @Override
   public CountryCode getCountry() { return CountryCode.MK; }
   @Override

--- a/src/main/java/org/iban4j/countryrules/algorithms/NlNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/NlNationalCheckDigit.java
@@ -6,6 +6,11 @@ import org.iban4j.countryrules.CountryRulesAlgorithm;
 
 /** Netherlands: Mod 11 with weights 10..1 on account number; allow Postbank starting with 000. */
 public final class NlNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Netherlands national check digit validator
+   */
+  public NlNationalCheckDigit() {
+  }
 
   @Override
   public CountryCode getCountry() { return CountryCode.NL; }

--- a/src/main/java/org/iban4j/countryrules/algorithms/NoNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/NoNationalCheckDigit.java
@@ -6,6 +6,12 @@ import org.iban4j.countryrules.CountryRulesAlgorithm;
 
 /** Norway: Mod 11 with weights 5,4,3,2,7,6,5,4,3,2 on bank+account vs 1-digit check. */
 public final class NoNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Norway national check digit validator
+   */
+  public NoNationalCheckDigit() {
+  }
+
   @Override
   public CountryCode getCountry() { return CountryCode.NO; }
   @Override

--- a/src/main/java/org/iban4j/countryrules/algorithms/PtNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/PtNationalCheckDigit.java
@@ -7,6 +7,12 @@ import org.iban4j.countryrules.CountryRulesAlgorithm;
 
 /** Portugal: ISO 7064 MOD 97-10 over BBAN. */
 public final class PtNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Portugal national check digit validator
+   */
+  public PtNationalCheckDigit() {
+  }
+
   @Override
   public CountryCode getCountry() { return CountryCode.PT; }
   @Override

--- a/src/main/java/org/iban4j/countryrules/algorithms/RsNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/RsNationalCheckDigit.java
@@ -7,6 +7,12 @@ import org.iban4j.countryrules.CountryRulesAlgorithm;
 
 /** Serbia: ISO 7064 MOD 97-10 over BBAN. */
 public final class RsNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Serbia national check digit validator
+   */
+  public RsNationalCheckDigit() {
+  }
+
   @Override
   public CountryCode getCountry() { return CountryCode.RS; }
   @Override

--- a/src/main/java/org/iban4j/countryrules/algorithms/SiNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/SiNationalCheckDigit.java
@@ -7,6 +7,12 @@ import org.iban4j.countryrules.CountryRulesAlgorithm;
 
 /** Slovenia: ISO 7064 MOD 97-10 over BBAN. */
 public final class SiNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Slovenia national check digit validator
+   */
+  public SiNationalCheckDigit() {
+  }
+
   @Override
   public CountryCode getCountry() { return CountryCode.SI; }
   @Override

--- a/src/main/java/org/iban4j/countryrules/algorithms/SkNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/SkNationalCheckDigit.java
@@ -6,6 +6,11 @@ import org.iban4j.countryrules.CountryRulesAlgorithm;
 
 /** Slovak Republic: Mod 11 two-part validation on account number (prefix and basic). */
 public final class SkNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Slovak Republic national check digit validator
+   */
+  public SkNationalCheckDigit() {
+  }
 
   @Override
   public CountryCode getCountry() { return CountryCode.SK; }

--- a/src/main/java/org/iban4j/countryrules/algorithms/TnNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/TnNationalCheckDigit.java
@@ -7,6 +7,12 @@ import org.iban4j.countryrules.util.Iso7064;
 
 /** Tunisia: RIB check-digits (numeric RIB from bank+branch+account). */
 public final class TnNationalCheckDigit implements CountryRulesAlgorithm {
+  /**
+   * Created instance of Tunisia national check digit validator
+   */
+  public TnNationalCheckDigit() {
+  }
+
   @Override
   public CountryCode getCountry() { return CountryCode.TN; }
 

--- a/src/main/java/org/iban4j/countryrules/util/Iso7064.java
+++ b/src/main/java/org/iban4j/countryrules/util/Iso7064.java
@@ -11,6 +11,8 @@ public final class Iso7064 {
 
   /**
    * Compute the MOD 97-10 remainder for a numeric string. Returns -1 for invalid input.
+   * @param numeric number represented as a string to compute MOD 97 operation
+   * @return result of MOD 97 operation or {@code -1} if {@code numeric} values is not a number
    */
   public static int mod97_10(final String numeric) {
     if (numeric == null || numeric.isEmpty()) {
@@ -31,6 +33,8 @@ public final class Iso7064 {
   /**
    * Compute French/Tunisian style RIB check digits: (number * 100) % 97 and 97 - remainder.
    * Returns the two-digit string or null on invalid input.
+   * @param numeric number represented as a string to compute RIB check digits
+   * @return RIB check digits or {@code null} if {@code numeric} values is not a number
    */
   public static String ribCheckDigits(final String numeric) {
     int remainder = mod97_10(numeric);


### PR DESCRIPTION
PR adds missing Javadoc to get rid of warnings during javadoc generation

Closes #157 