### PR TITLE
fix: include bankCode in ES national check digit computation

### DIFF
--- a/src/main/java/org/iban4j/countryrules/algorithms/EsNationalCheckDigit.java
+++ b/src/main/java/org/iban4j/countryrules/algorithms/EsNationalCheckDigit.java
@@ -4,7 +4,7 @@ import org.iban4j.CountryCode;
 import org.iban4j.Iban;
 import org.iban4j.countryrules.CountryRulesAlgorithm;
 
-/** Spain: dual modulus 11 with weights 1,2,4,8,5,10,9,7,3,6 over 00+branch and account. */
+/** Spain: dual modulus 11 with weights 1,2,4,8,5,10,9,7,3,6 over 00+bank+branch and account. */
 public final class EsNationalCheckDigit implements CountryRulesAlgorithm {
 
   private static final int[] WEIGHTS = {1, 2, 4, 8, 5, 10, 9, 7, 3, 6};
@@ -31,7 +31,7 @@ public final class EsNationalCheckDigit implements CountryRulesAlgorithm {
       return false;
     }
 
-    final String firstData = "00" + branchCode;
+    final String firstData = "00" + bankCode + branchCode;
     final int firstCd = calculateCheckDigit(firstData);
     if (firstCd < 0) {
         return false;

--- a/src/test/java/org/iban4j/TestDataHelper.java
+++ b/src/test/java/org/iban4j/TestDataHelper.java
@@ -733,6 +733,16 @@ final class TestDataHelper {
           },
           {
             new Iban.Builder()
+                .countryCode(CountryCode.ES)
+                .bankCode("0049")
+                .branchCode("5525")
+                .accountNumber("2810597769")
+                .nationalCheckDigit("59")
+                .build(),
+            "ES4000495525592810597769"
+          },
+          {
+            new Iban.Builder()
                 .countryCode(CountryCode.SE)
                 .bankCode("500")
                 .accountNumber("0000005839825746")

--- a/src/test/java/org/iban4j/countryrules/CountryRulesAlgorithmTest.java
+++ b/src/test/java/org/iban4j/countryrules/CountryRulesAlgorithmTest.java
@@ -58,7 +58,10 @@ public class CountryRulesAlgorithmTest {
         
         Iban validIban = Iban.valueOf("ES9121000418450200051332");
         assertTrue(algorithm.validate(validIban));
-        
+
+        Iban validIban2 = Iban.valueOf("ES4000495525592810597769");
+        assertTrue(algorithm.validate(validIban2));
+
         Iban invalidIban = Iban.valueOf("ES4221000418450200061332");
         assertFalse(algorithm.validate(invalidIban));
     }

--- a/src/test/java/org/iban4j/countryrules/NationalCheckDigitAlgorithmTest.java
+++ b/src/test/java/org/iban4j/countryrules/NationalCheckDigitAlgorithmTest.java
@@ -58,7 +58,10 @@ public class NationalCheckDigitAlgorithmTest {
         
         Iban validIban = Iban.valueOf("ES9121000418450200051332");
         assertTrue(algorithm.validate(validIban));
-        
+
+        Iban validIban2 = Iban.valueOf("ES4000495525592810597769");
+        assertTrue(algorithm.validate(validIban2));
+
         Iban invalidIban = Iban.valueOf("ES4221000418450200061332");
         assertFalse(algorithm.validate(invalidIban));
     }


### PR DESCRIPTION
## Summary

The Spanish national check digit algorithm (`EsNationalCheckDigit`) has a bug: it computes the first check digit from `"00" + branchCode` (6 digits) instead of `"00" + bankCode + branchCode` (10 digits).

Per the CCC (Código Cuenta Cliente) standard, the first control digit must be calculated over the full 10-digit string `00 + entity (bank) code + branch code`. The current code omits the 4-digit bank code entirely.

### Why the existing test didn't catch it

The original test IBAN `ES9121000418450200051332` passes **by coincidence** — the difference in weighted sums between the correct and incorrect input happens to be divisible by 11, so both computations yield the same check digit. This masked the bug.

The IBAN `ES4000495525592810597769` exposes the problem: the correct national check digit is `59`, but the buggy code computes `19`.

## Changes

- **`EsNationalCheckDigit.java`** — Changed `"00" + branchCode` → `"00" + bankCode + branchCode` on the first check digit computation
- **`CountryRulesAlgorithmTest.java`** / **`NationalCheckDigitAlgorithmTest.java`** — Added `ES4000495525592810597769` as a second valid IBAN assertion in the Spain test
- **`TestDataHelper.java`** — Added corresponding test data entry (bankCode=0049, branchCode=5525, nationalCheckDigit=59, accountNumber=2810597769)

## Test plan

- [x] Full test suite passes (`mvn test` — 892 tests, 0 failures)
- [x] New IBAN `ES4000495525592810597769` validates correctly after fix
- [x] Original IBAN `ES9121000418450200051332` still validates correctly