### PR TITLE
feat: expose public validateBban and extractBbanEntry on IbanUtil (#170)

### DIFF
--- a/src/main/java/org/iban4j/IbanUtil.java
+++ b/src/main/java/org/iban4j/IbanUtil.java
@@ -71,10 +71,8 @@ public final class IbanUtil {
             validateCountryCode(iban);
             validateCheckDigitPresence(iban);
 
-            final BbanStructure structure = getBbanStructure(iban);
-
-            validateBbanLength(iban, structure);
-            validateBbanEntries(iban, structure);
+            final CountryCode countryCode = CountryCode.getByCode(getCountryCode(iban));
+            validateBban(countryCode, getBban(iban));
 
             validateCheckDigit(iban);
         } catch (Iban4jException e) {
@@ -82,6 +80,85 @@ public final class IbanUtil {
         } catch (RuntimeException e) {
             throw new IbanFormatException(UNKNOWN, e.getMessage());
         }
+    }
+
+    /**
+     * Validates a BBAN against the structure of the given country.
+     * <p>
+     * Performs BBAN length and per-entry character-class checks. Does <em>not</em>
+     * run the IBAN mod-97 check, since a raw BBAN has no country/check-digit prefix.
+     *
+     * @param country the country whose BBAN structure to validate against.
+     * @param bban the raw BBAN to validate.
+     * @throws IbanFormatException if {@code country} or {@code bban} is null,
+     *         if the BBAN length does not match the country's expected length,
+     *         or if any BBAN entry has an invalid character.
+     * @throws UnsupportedCountryException if the country has no registered BBAN structure.
+     */
+    public static void validateBban(final CountryCode country, final String bban)
+            throws IbanFormatException, UnsupportedCountryException {
+        if (country == null) {
+            throw new IbanFormatException("Country must not be null.");
+        }
+        if (bban == null) {
+            throw new IbanFormatException("BBAN must not be null.");
+        }
+        final BbanStructure structure = BbanStructure.forCountry(country);
+        if (structure == null) {
+            throw new UnsupportedCountryException(country.toString(),
+                    "Country code is not supported.");
+        }
+        validateBbanLength(bban, structure);
+        int offset = 0;
+        for (final BbanStructureEntry entry : structure.getEntries()) {
+            final int entryLength = entry.getLength();
+            final String entryValue = bban.substring(offset, offset + entryLength);
+            offset += entryLength;
+            BbanStructure.validateBbanEntry(entry, entryValue);
+        }
+    }
+
+    /**
+     * Extracts the value of the given BBAN entry type from a raw BBAN.
+     * <p>
+     * Validates only the BBAN length and that {@code entryType} exists for {@code country};
+     * the returned slice is <em>not</em> character-validated (mirrors {@link #getBankCode(String)}
+     * behavior). Call {@link #validateBban(CountryCode, String)} first if you need to be sure the
+     * slice conforms to the entry's character class.
+     *
+     * @param country the country whose BBAN structure to use.
+     * @param bban the raw BBAN to extract from.
+     * @param entryType the entry to extract.
+     * @return the BBAN slice corresponding to {@code entryType}.
+     * @throws IbanFormatException if any argument is null, if the BBAN length is wrong,
+     *         or if the country's BBAN structure does not include {@code entryType}.
+     * @throws UnsupportedCountryException if the country has no registered BBAN structure.
+     */
+    public static String extractBbanEntry(final CountryCode country, final String bban,
+                                          final BbanEntryType entryType)
+            throws IbanFormatException, UnsupportedCountryException {
+        if (country == null) {
+            throw new IbanFormatException("Country must not be null.");
+        }
+        if (bban == null) {
+            throw new IbanFormatException("BBAN must not be null.");
+        }
+        if (entryType == null) {
+            throw new IbanFormatException("Entry type must not be null.");
+        }
+        final BbanStructure structure = BbanStructure.forCountry(country);
+        if (structure == null) {
+            throw new UnsupportedCountryException(country.toString(),
+                    "Country code is not supported.");
+        }
+        validateBbanLength(bban, structure);
+        final String value = findBbanEntry(structure, bban, entryType);
+        if (value == null) {
+            throw new IbanFormatException(BBAN_INVALID_ENTRY_TYPE,
+                    String.format("Entry type [%s] does not exist for country [%s]",
+                            entryType.name(), country));
+        }
+        return value;
     }
 
     /**
@@ -410,33 +487,15 @@ public final class IbanUtil {
         }
     }
 
-    private static void validateBbanLength(final String iban,
+    private static void validateBbanLength(final String bban,
                                            final BbanStructure structure) {
         final int expectedBbanLength = structure.getBbanLength();
-        final String bban = getBban(iban);
         final int bbanLength = bban.length();
         if (expectedBbanLength != bbanLength) {
             throw new IbanFormatException(BBAN_LENGTH,
                     bbanLength, expectedBbanLength,
                     String.format("[%s] length is %d, expected BBAN length is: %d",
                             bban, bbanLength, expectedBbanLength));
-        }
-    }
-
-    private static void validateBbanEntries(final String iban,
-                                            final BbanStructure structure) {
-        final String bban = getBban(iban);
-        final CountryCode countryCode = CountryCode.getByCode(getCountryCode(iban));
-        int bbanEntryOffset = 0;
-
-        for (final BbanStructureEntry entry : structure.getEntries()) {
-            final int entryLength = entry.getLength();
-            final String entryValue = bban.substring(bbanEntryOffset,
-                    bbanEntryOffset + entryLength);
-
-            bbanEntryOffset += entryLength;
-
-            BbanStructure.validateBbanEntry(countryCode, entry.getEntryType(), entryValue);
         }
     }
 
@@ -477,18 +536,18 @@ public final class IbanUtil {
     }
 
     private static String extractBbanEntry(final String iban, final BbanEntryType entryType) {
-        final String bban = getBban(iban);
-        final BbanStructure structure = getBbanStructure(iban);
-        int bbanEntryOffset = 0;
-        for(final BbanStructureEntry entry : structure.getEntries()) {
-            final int entryLength = entry.getLength();
-            final String entryValue = bban.substring(bbanEntryOffset,
-                    bbanEntryOffset + entryLength);
+        return findBbanEntry(getBbanStructure(iban), getBban(iban), entryType);
+    }
 
-            bbanEntryOffset = bbanEntryOffset + entryLength;
+    private static String findBbanEntry(final BbanStructure structure, final String bban,
+                                        final BbanEntryType entryType) {
+        int offset = 0;
+        for (final BbanStructureEntry entry : structure.getEntries()) {
+            final int entryLength = entry.getLength();
             if (entry.getEntryType() == entryType) {
-                return entryValue;
+                return bban.substring(offset, offset + entryLength);
             }
+            offset += entryLength;
         }
         return null;
     }

--- a/src/main/java/org/iban4j/bban/BbanStructure.java
+++ b/src/main/java/org/iban4j/bban/BbanStructure.java
@@ -689,6 +689,21 @@ public class BbanStructure {
                     String.format(INVALID_ENTRY_TYPE,
                             entryType.name(), countryCode)));
 
+    validateBbanEntry(entry, entryValue);
+  }
+
+  /**
+   * Validates a BBAN entry value against a known {@link BbanStructureEntry} definition.
+   * <p>
+   * Use this overload when you already hold the entry (e.g. while iterating
+   * {@link #getEntries()}) to avoid the country-and-entry-type lookup performed by
+   * {@link #validateBbanEntry(CountryCode, BbanEntryType, String)}.
+   *
+   * @param entry      the BBAN structure entry defining length and character type.
+   * @param entryValue the value to validate.
+   * @throws IbanFormatException if the value's length or character type is invalid.
+   */
+  public static void validateBbanEntry(final BbanStructureEntry entry, final String entryValue) {
     validateBbanEntryLength(entry, entryValue);
     validateBbanEntryCharacterType(entry, entryValue);
   }

--- a/src/test/java/org/iban4j/IbanUtilBbanTest.java
+++ b/src/test/java/org/iban4j/IbanUtilBbanTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2013 Artur Mkrtchyan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.iban4j;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.iban4j.bban.BbanEntryType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("IbanUtil BBAN public API")
+public class IbanUtilBbanTest {
+
+    @Nested
+    @DisplayName("validateBban")
+    class ValidateBban {
+
+        @Test
+        @DisplayName("accepts a valid German BBAN")
+        void acceptsValidGermanBban() {
+            // DE: bankCode(8,n) + accountNumber(10,n) — total 18
+            IbanUtil.validateBban(CountryCode.DE, "370400440532013000");
+        }
+
+        @Test
+        @DisplayName("accepts a valid Norwegian BBAN with national check digit")
+        void acceptsValidNorwegianBban() {
+            // NO: bankCode(4,n) + accountNumber(6,n) + nationalCheckDigit(1,n) — total 11
+            IbanUtil.validateBban(CountryCode.NO, "86011117947");
+        }
+
+        @Test
+        @DisplayName("accepts a valid Spanish BBAN where national check digit is mid-structure")
+        void acceptsValidSpanishBban() {
+            // ES: bankCode(4,n) + branchCode(4,n) + nationalCheckDigit(2,n) + accountNumber(10,n) — total 20
+            IbanUtil.validateBban(CountryCode.ES, "21000418450200051332");
+        }
+
+        @Test
+        @DisplayName("accepts a valid Brazilian BBAN with all character classes")
+        void acceptsValidBrazilianBban() {
+            // BR: bankCode(8,n) + branchCode(5,n) + accountNumber(10,n) + accountType(1,a) + ownerAccountNumber(1,c) — total 25
+            IbanUtil.validateBban(CountryCode.BR, "00360305000010009795493P1");
+        }
+
+        @Test
+        @DisplayName("accepts a valid GB BBAN with letter bank code")
+        void acceptsValidGbBban() {
+            // GB: bankCode(4,a) + branchCode(6,n) + accountNumber(8,n) — total 18
+            IbanUtil.validateBban(CountryCode.GB, "WEST12345698765432");
+        }
+
+        @Test
+        @DisplayName("rejects BBAN that is too short")
+        void rejectsTooShortBban() {
+            IbanFormatException ex = assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.validateBban(CountryCode.DE, "12345"));
+            assertEquals(IbanFormatException.IbanFormatViolation.BBAN_LENGTH,
+                    ex.getFormatViolation());
+        }
+
+        @Test
+        @DisplayName("rejects BBAN that is too long")
+        void rejectsTooLongBban() {
+            IbanFormatException ex = assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.validateBban(CountryCode.DE, "3704004405320130001234567890"));
+            assertEquals(IbanFormatException.IbanFormatViolation.BBAN_LENGTH,
+                    ex.getFormatViolation());
+        }
+
+        @Test
+        @DisplayName("rejects BBAN with non-digit in numeric slot")
+        void rejectsNonDigitInNumericSlot() {
+            // DE expects all digits — inject a letter
+            IbanFormatException ex = assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.validateBban(CountryCode.DE, "370400440A32013000"));
+            assertEquals(IbanFormatException.IbanFormatViolation.BBAN_ONLY_DIGITS,
+                    ex.getFormatViolation());
+        }
+
+        @Test
+        @DisplayName("rejects BBAN with digit in letters-only slot")
+        void rejectsDigitInLettersOnlySlot() {
+            // GB bankCode is 'a' — inject a digit
+            IbanFormatException ex = assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.validateBban(CountryCode.GB, "WE1T12345698765432"));
+            assertEquals(IbanFormatException.IbanFormatViolation.BBAN_ONLY_UPPER_CASE_LETTERS,
+                    ex.getFormatViolation());
+        }
+
+        @Test
+        @DisplayName("rejects BBAN with non-alphanumeric in 'c' slot")
+        void rejectsNonAlphanumericInCSlot() {
+            // BR ownerAccountNumber is 'c' — last char. Replace with '!'.
+            IbanFormatException ex = assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.validateBban(CountryCode.BR, "00360305000010009795493P!"));
+            assertEquals(IbanFormatException.IbanFormatViolation.BBAN_ONLY_DIGITS_OR_LETTERS,
+                    ex.getFormatViolation());
+        }
+
+        @Test
+        @DisplayName("rejects null BBAN")
+        void rejectsNullBban() {
+            assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.validateBban(CountryCode.DE, null));
+        }
+
+        @Test
+        @DisplayName("rejects null country")
+        void rejectsNullCountry() {
+            assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.validateBban(null, "370400440532013000"));
+        }
+
+        @Test
+        @DisplayName("rejects unsupported country")
+        void rejectsUnsupportedCountry() {
+            // US is a valid CountryCode enum but has no BBAN structure registered
+            assertThrows(UnsupportedCountryException.class,
+                    () -> IbanUtil.validateBban(CountryCode.US, "12345678"));
+        }
+    }
+
+    @Nested
+    @DisplayName("extractBbanEntry")
+    class ExtractBbanEntry {
+
+        @Test
+        @DisplayName("extracts bank code from DE BBAN")
+        void extractsBankCodeFromDeBban() {
+            String result = IbanUtil.extractBbanEntry(CountryCode.DE,
+                    "370400440532013000", BbanEntryType.bank_code);
+            assertEquals("37040044", result);
+        }
+
+        @Test
+        @DisplayName("extracts account number from DE BBAN")
+        void extractsAccountNumberFromDeBban() {
+            String result = IbanUtil.extractBbanEntry(CountryCode.DE,
+                    "370400440532013000", BbanEntryType.account_number);
+            assertEquals("0532013000", result);
+        }
+
+        @Test
+        @DisplayName("extracts national check digit from NO BBAN")
+        void extractsNationalCheckDigitFromNoBban() {
+            String result = IbanUtil.extractBbanEntry(CountryCode.NO,
+                    "86011117947", BbanEntryType.national_check_digit);
+            assertEquals("7", result);
+        }
+
+        @Test
+        @DisplayName("extracts mid-structure national check digit from ES BBAN")
+        void extractsMidStructureNationalCheckDigitFromEsBban() {
+            String result = IbanUtil.extractBbanEntry(CountryCode.ES,
+                    "21000418450200051332", BbanEntryType.national_check_digit);
+            assertEquals("45", result);
+        }
+
+        @Test
+        @DisplayName("extracts owner account number from BR BBAN")
+        void extractsOwnerAccountNumberFromBrBban() {
+            String result = IbanUtil.extractBbanEntry(CountryCode.BR,
+                    "00360305000010009795493P1", BbanEntryType.owner_account_number);
+            assertEquals("1", result);
+        }
+
+        @Test
+        @DisplayName("rejects request for entry type the country does not have")
+        void rejectsMissingEntryType() {
+            // DE has no branch_code
+            IbanFormatException ex = assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.extractBbanEntry(CountryCode.DE,
+                            "370400440532013000", BbanEntryType.branch_code));
+            assertEquals(IbanFormatException.IbanFormatViolation.BBAN_INVALID_ENTRY_TYPE,
+                    ex.getFormatViolation());
+        }
+
+        @Test
+        @DisplayName("rejects BBAN with wrong length")
+        void rejectsWrongLengthBban() {
+            IbanFormatException ex = assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.extractBbanEntry(CountryCode.DE,
+                            "12345", BbanEntryType.bank_code));
+            assertEquals(IbanFormatException.IbanFormatViolation.BBAN_LENGTH,
+                    ex.getFormatViolation());
+        }
+
+        @Test
+        @DisplayName("rejects null bban")
+        void rejectsNullBban() {
+            assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.extractBbanEntry(CountryCode.DE,
+                            null, BbanEntryType.bank_code));
+        }
+
+        @Test
+        @DisplayName("rejects null country")
+        void rejectsNullCountry() {
+            assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.extractBbanEntry(null,
+                            "370400440532013000", BbanEntryType.bank_code));
+        }
+
+        @Test
+        @DisplayName("rejects null entry type")
+        void rejectsNullEntryType() {
+            assertThrows(IbanFormatException.class,
+                    () -> IbanUtil.extractBbanEntry(CountryCode.DE,
+                            "370400440532013000", null));
+        }
+
+        @Test
+        @DisplayName("rejects unsupported country")
+        void rejectsUnsupportedCountry() {
+            assertThrows(UnsupportedCountryException.class,
+                    () -> IbanUtil.extractBbanEntry(CountryCode.US,
+                            "12345678", BbanEntryType.bank_code));
+        }
+    }
+
+    @Nested
+    @DisplayName("Internal extractor regression — Iban getters keep returning null")
+    class InternalExtractorRegression {
+
+        @Test
+        @DisplayName("Iban.getBranchCode() returns null on DE (no branch code)")
+        void deBranchCodeIsNull() {
+            assertNull(Iban.valueOf("DE89370400440532013000").getBranchCode());
+        }
+
+        @Test
+        @DisplayName("Iban.getNationalCheckDigit() returns null on DE (no national check digit)")
+        void deNationalCheckDigitIsNull() {
+            assertNull(Iban.valueOf("DE89370400440532013000").getNationalCheckDigit());
+        }
+
+        @Test
+        @DisplayName("Iban.getAccountType() returns null on DE (no account type)")
+        void deAccountTypeIsNull() {
+            assertNull(Iban.valueOf("DE89370400440532013000").getAccountType());
+        }
+
+        @Test
+        @DisplayName("Iban.getOwnerAccountType() returns null on DE (no owner account number)")
+        void deOwnerAccountTypeIsNull() {
+            assertNull(Iban.valueOf("DE89370400440532013000").getOwnerAccountType());
+        }
+
+        @Test
+        @DisplayName("Iban.getIdentificationNumber() returns null on DE (no identification number)")
+        void deIdentificationNumberIsNull() {
+            assertNull(Iban.valueOf("DE89370400440532013000").getIdentificationNumber());
+        }
+    }
+}


### PR DESCRIPTION
Closes #170.

## Summary
- Adds `IbanUtil.validateBban(CountryCode, String)` — length and per-entry character-class checks on a raw BBAN. No mod-97 check, since a raw BBAN has no country/check-digit prefix.
- Adds `IbanUtil.extractBbanEntry(CountryCode, String, BbanEntryType)` — slices a single BBAN entry. Validates length and entry-type existence; mirrors `getBankCode(String)` by not character-validating the returned slice (Javadoc directs callers to `validateBban` first when that matters).
- Refactors `IbanUtil.validate(String)` to delegate the BBAN portion to `validateBban`, collapsing the previous `validateBbanLength` + `validateBbanEntries` pair.
- Internal `extractBbanEntry(iban, entryType)` shares a new `findBbanEntry` helper with the public overload — preserving the null-return contract relied on by `Iban.getBranchCode()`, `getNationalCheckDigit()`, `getAccountType()`, `getOwnerAccountType()`, `getIdentificationNumber()` (covered by a regression block in the new test).
- Adds a public `BbanStructure.validateBbanEntry(BbanStructureEntry, String)` overload so iterators already holding the entry skip a per-entry `forCountry()` lookup.

## Why
Issue #170: callers want to validate or destructure a raw BBAN without first wrapping it in an `Iban`. Today the only way to do that is to copy internal helpers or build a fake IBAN.

## Test plan
- [x] `IbanUtilBbanTest` — 29 new cases:
  - `validateBban`: happy paths for DE/NO/ES/BR/GB (covers `n`, `a`, `c` character classes and mid-structure entries), length errors (too short / too long), per-character-class violations, null country / null bban, unsupported country.
  - `extractBbanEntry`: happy-path extraction for DE bank code, DE account number, NO national check digit, ES mid-structure national check digit, BR owner account number; missing entry type, wrong-length BBAN, null arguments, unsupported country.
  - Regression block: `Iban.getBranchCode()`, `getNationalCheckDigit()`, `getAccountType()`, `getOwnerAccountType()`, `getIdentificationNumber()` still return `null` for DE (which has none of those entries).
- [x] Full suite: `./mvnw test` — 917 passed, 0 failed, 2 skipped.